### PR TITLE
Feat : api 메서드 구조 설계

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 dist
 
 .yarn/install-state.gz
+
+.env

--- a/src/apis/messages.ts
+++ b/src/apis/messages.ts
@@ -1,0 +1,41 @@
+import API_URL, { DELETE, PUT } from '@/constants/api';
+import { requester } from './requester';
+
+export const deleteMessage = async (messageId: string) => {
+	const {
+		messages: { index },
+	} = API_URL;
+
+	try {
+		const data = {
+			messageIds: [messageId],
+		};
+
+		const { status } = await requester({
+			method: DELETE,
+			url: index,
+			data,
+		});
+
+		return status;
+	} catch (error) {
+		// 에러 핸들링
+	}
+};
+
+export const readMessage = async (messageId: string) => {
+	const {
+		messages: { read },
+	} = API_URL;
+
+	try {
+		const { status } = await requester({
+			method: PUT,
+			url: `${read}?messageId=${messageId}`,
+		});
+
+		return status;
+	} catch (error) {
+		// 에러 핸들링
+	}
+};

--- a/src/apis/requester.ts
+++ b/src/apis/requester.ts
@@ -3,7 +3,7 @@ import { getStorageItem, storageAccessKey } from '@/utils/local-storage';
 
 const createAxiosInstance = () => {
 	const base = axios.create({
-		baseURL: process.env.API_BASE_URL,
+		baseURL: import.meta.env.VITE_API_BASE_URL,
 	});
 
 	base.interceptors.response.use(

--- a/src/apis/requester.ts
+++ b/src/apis/requester.ts
@@ -1,0 +1,56 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { getStorageItem, storageAccessKey } from '@/utils/local-storage';
+
+const createAxiosInstance = () => {
+	const base = axios.create({
+		baseURL: process.env.API_BASE_URL,
+	});
+
+	base.interceptors.response.use(
+		async (response) => {
+			const { config, data } = response;
+
+			if (data?.statusCode >= 400 && data?.statusCode < 500) {
+				// 토큰 재발급
+
+				return axios(config);
+			}
+
+			return response;
+		},
+		async (error) => {
+			const {
+				config,
+				response: { status },
+			} = error;
+
+			if (status >= 400 && status < 500) {
+				// 토큰 재발급
+
+				return axios(config);
+			}
+
+			return error;
+		},
+	);
+
+	return base;
+};
+
+const axiosInstance = createAxiosInstance();
+
+export async function requester<Payload>(option: AxiosRequestConfig) {
+	const accessToken = getStorageItem(storageAccessKey);
+
+	const response: AxiosResponse<Payload> = await axiosInstance({
+		headers: {
+			Authorization: accessToken ? `Bearer ${accessToken}` : '',
+		},
+		...option,
+	});
+
+	return {
+		status: response.status,
+		payload: response.data,
+	};
+}

--- a/src/apis/requester.ts
+++ b/src/apis/requester.ts
@@ -4,6 +4,7 @@ import { getStorageItem, storageAccessKey } from '@/utils/local-storage';
 const createAxiosInstance = () => {
 	const base = axios.create({
 		baseURL: import.meta.env.VITE_API_BASE_URL,
+		withCredentials: true,
 	});
 
 	base.interceptors.response.use(

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,18 @@
+export const GET = 'GET';
+export const PUT = 'PUT';
+export const DELETE = 'DELETE';
+export const POST = 'POST';
+
+const API_URL = {
+	auth: {
+		signin: '/signin',
+		refresh: '/refresh-token',
+	},
+	messages: {
+		index: '/messages',
+		folder: '/messages/folder',
+		read: '/messages/alreadyRead',
+	},
+};
+
+export default API_URL;

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -1,0 +1,20 @@
+export const storageAccessKey = 'BETREE_STORAGE_ACCESS_KEY';
+export const storageRefreshKey = 'BETREE_STORAGE_REFRESH_KEY';
+
+export const getStorageItem = (key: string, initialValue = '') => {
+	try {
+		const item = window.localStorage.getItem(key);
+
+		return item ? JSON.parse(item) : initialValue;
+	} catch (error) {
+		return initialValue;
+	}
+};
+
+export const setStorageItem = (key: string, value: string) => {
+	window.localStorage.setItem(key, JSON.stringify(value));
+};
+
+export const removeStorageItem = (key: string) => {
+	window.localStorage.removeItem(key);
+};


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- #26 

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 기본적인 api 요청 메서드를 추가했습니다.
`axios instance` 를 공통으로 관리하기 위해 따로 `requester` 메서드를 만들었습니다.
`api url` 도 상수로 관리합니다.

<br><br>

### 💡 필요한 후속작업이 있어요.

- 토큰을 local storage 에서 관리하려 하는데 다른 의견 있으시면 말씀 부탁드립니다.
- 추가한 코드처럼 앞으로 api 폴더에서 api 종류별로 파일을 만들어서 api를 사용하는 메서드들을 모아두면 좋을 것 같은데
이것도 어떤지 말씀해주세요~
- 에러 핸들링을 어떻게 할지 추후 논의가 필요합니다.
- 각자 .env 파일 추가해주셔야 합니다.

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
