### PR TITLE
Feat : 로그인 기능 추가

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,27 @@
+import API_URL, { POST } from '@/constants/api';
+import { setStorageItem, storageAccessKey } from '@/utils/local-storage';
+import { requester } from './requester';
+
+export const login = async (kakaoAccessToken: string) => {
+	const {
+		auth: { signin },
+	} = API_URL;
+
+	try {
+		const { headers, status } = await requester({
+			method: POST,
+			url: signin,
+			headers: {
+				'X-Kakao-Access-Token': kakaoAccessToken,
+			},
+		});
+
+		const betreeAccessToken = headers.authorization.split(' ')[1];
+
+		setStorageItem(storageAccessKey, betreeAccessToken);
+
+		return status;
+	} catch (error) {
+		// 에러 핸들링
+	}
+};

--- a/src/apis/requester.ts
+++ b/src/apis/requester.ts
@@ -52,6 +52,7 @@ export async function requester<Payload>(option: AxiosRequestConfig) {
 
 	return {
 		status: response.status,
+		headers: response.headers,
 		payload: response.data,
 	};
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -3,6 +3,9 @@ export const PUT = 'PUT';
 export const DELETE = 'DELETE';
 export const POST = 'POST';
 
+export const RESPONSE_SUCCESS_OK = 200;
+export const RESPONSE_SUCCESS_CREATED = 201;
+
 const API_URL = {
 	auth: {
 		signin: '/signin',

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import BigTreeLogo from '@/assets/images/shared/big_tree_logo.svg';
 import KakaoLogin from '@/assets/images/login/kakao_login_large_wide@2x.png';
 import * as S from './Login.styled';
+import useLogin from './useLogin';
 
 const Login = () => {
+	const handleClickLoginButton = useLogin();
+
 	return (
 		<S.LoginContainer>
 			<S.ServiceInfo>
@@ -12,7 +15,7 @@ const Login = () => {
 				<p>아카이브 서비스, Betree</p>
 			</S.ServiceInfo>
 
-			<S.KakaoLoginButton type="button">
+			<S.KakaoLoginButton type="button" onClick={handleClickLoginButton}>
 				<img src={KakaoLogin} alt="카카오로 시작하기" />
 			</S.KakaoLoginButton>
 		</S.LoginContainer>

--- a/src/pages/Login/useLogin.ts
+++ b/src/pages/Login/useLogin.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { login } from '@/apis/auth';
+import { RESPONSE_SUCCESS_CREATED } from '@/constants/api';
+
+const useLogin = () => {
+	const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${
+		import.meta.env.VITE_REST_API_KEY
+	}&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`;
+
+	const handleClickLoginButton = () => {
+		window.location.href = KAKAO_LOGIN_URL;
+	};
+
+	const getKakaoAccessToken = async (kakaoCode: string) => {
+		const data: {
+			[key: string]: string;
+		} = {
+			grant_type: 'authorization_code',
+			client_id: import.meta.env.VITE_REST_API_KEY,
+			redirect_uri: import.meta.env.VITE_REDIRECT_URI,
+			code: kakaoCode,
+		};
+
+		const qsData = Object.keys(data)
+			.map((k) => encodeURIComponent(k) + '=' + encodeURI(data[k]))
+			.join('&');
+
+		const response = await axios.post('https://kauth.kakao.com/oauth/token', qsData, {
+			headers: {
+				'Content-type': 'application/x-www-form-urlencoded',
+			},
+		});
+
+		const kakaoAccessToken = await response.data.access_token;
+
+		return kakaoAccessToken;
+	};
+
+	const location = useLocation();
+
+	const navigate = useNavigate();
+
+	const handlelogin = useCallback(async () => {
+		const kakaoCode = location.search.split('=')[1];
+
+		if (!kakaoCode) return;
+
+		const kakaoAccessToken = await getKakaoAccessToken(kakaoCode);
+
+		const status = await login(kakaoAccessToken);
+
+		if (status === RESPONSE_SUCCESS_CREATED) {
+			navigate('/');
+		}
+	}, [location, navigate]);
+
+	useEffect(() => {
+		handlelogin();
+	}, [handlelogin]);
+
+	return handleClickLoginButton;
+};
+
+export default useLogin;

--- a/src/pages/MessageDetail/MessageDetail.tsx
+++ b/src/pages/MessageDetail/MessageDetail.tsx
@@ -17,6 +17,7 @@ const MessageDetail = () => {
 		() => messageDetailFetcher(messageId),
 		{
 			refetchOnWindowFocus: false,
+			retry: 1,
 		},
 	);
 


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- #31 

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- `requester` 메서드가 로그인 기능에 필요한 `response.header` 까지 반환하도록 수정되었습니다.
- 200, 201 등의 `status code` 도 상수로 관리하도록 하였습니다.
- 토큰은 로컬 스토리지에 저장하도록 하였습니다.

<br><br>

### 💡 필요한 후속작업이 있어요.

- 카카오 로그인이 처음이라 혹시 동작하지 않거나 개선할 부분 있다면 말씀 부탁드립니다~
- `axios.interceptor` 로 토큰이 만료되었을 때 재발급하는 로직이 필요합니다.
- `.env` 파일에 카카오 로그인 관련 환경 변수 추가가 필요합니다.

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
