### PR TITLE
[#46] Feat: 물 주기 완료 모달 UI 구현

### DIFF
--- a/src/components/shared/Modal/ModalFrame.styled.ts
+++ b/src/components/shared/Modal/ModalFrame.styled.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
-import { ModalBackDropStyledPropsType } from './type';
+import { StyledProps } from './type';
 
-export const ModalBackDrop = styled.div<ModalBackDropStyledPropsType>`
+export const ModalBackDrop = styled.div<StyledProps>`
 	position: fixed;
 	display: ${({ show }) => (show ? 'flex' : 'none')};
 	align-items: center;

--- a/src/components/shared/Modal/ModalFrame.tsx
+++ b/src/components/shared/Modal/ModalFrame.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import * as S from './ModalFrame.styled';
 import ModalPortal from './ModalPortal';
-import { ModalFramePropsType } from './type';
+import { Props } from './type';
 
-const ModalFrame = ({ children, onModal, setOnModal }: ModalFramePropsType) => {
+const ModalFrame = ({ children, onModal, setOnModal }: Props) => {
 	return (
 		<ModalPortal>
-			<S.ModalBackDrop show={onModal} onClick={() => setOnModal(false)}></S.ModalBackDrop>
+			<S.ModalBackDrop show={onModal} onClick={() => setOnModal(false)} />
 			{children}
 		</ModalPortal>
 	);

--- a/src/components/shared/Modal/SuccessModal/SuccessModal.styled.ts
+++ b/src/components/shared/Modal/SuccessModal/SuccessModal.styled.ts
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+
+export const ModalContainer = styled.div`
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	z-index: 1000;
+`;
+
+export const ModalWrapper = styled.div`
+	min-width: 350px;
+	min-height: 496px;
+	border-radius: 20px;
+	background-color: ${({ theme }) => theme.colors.bt_white};
+`;
+
+export const WateringImgWrapper = styled.div`
+	text-align: center;
+`;
+
+export const WateringImg = styled.img`
+	width: 120px;
+	height: auto;
+	margin: 72px 0 31px 0;
+	border-radius: 50%;
+	box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+`;
+
+export const MessageTitle = styled.h3`
+	margin-bottom: 43px;
+	text-align: center;
+	font-size: ${({ theme }) => theme.fontSize.f20};
+	font-weight: ${({ theme }) => theme.fontWeight.semiBold};
+	line-height: ${({ theme }) => theme.lineHeight.lh20};
+	letter-spacing: -0.02em;
+	color: ${({ theme }) => theme.colors.bt_grey[120]};
+`;
+
+export const MessageDescWrapper = styled.span`
+	margin-bottom: 83px;
+
+	& > p {
+		margin-bottom: 0.5em;
+
+		text-align: center;
+		font-size: ${({ theme }) => theme.fontSize.f16};
+		font-weight: ${({ theme }) => theme.fontWeight.normal};
+		line-height: ${({ theme }) => theme.lineHeight.lh16};
+		letter-spacing: -0.02em;
+		color: ${({ theme }) => theme.colors.bt_grey[85]};
+	}
+
+	& > p:nth-last-of-type(1) {
+		margin-bottom: 83px;
+	}
+`;
+
+export const ConfirmBtnWrapper = styled.div`
+	padding: 0 32px;
+`;

--- a/src/components/shared/Modal/SuccessModal/SuccessModal.type.ts
+++ b/src/components/shared/Modal/SuccessModal/SuccessModal.type.ts
@@ -1,0 +1,4 @@
+export type Props = {
+	isSucceedSendMessage: boolean;
+	handleCloseBtnClick: () => void;
+};

--- a/src/components/shared/Modal/SuccessModal/index.tsx
+++ b/src/components/shared/Modal/SuccessModal/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import ModalFrame from '../ModalFrame';
+import * as S from './SuccessModal.styled';
+import WateringIcon from '@/assets/images/noticeTree/watering_icon.svg';
+import Button from '../../Button';
+import { Props } from './SuccessModal.type';
+
+const SuccessModal = ({ isSucceedSendMessage, handleCloseBtnClick }: Props) => {
+	return (
+		<ModalFrame onModal={isSucceedSendMessage} setOnModal={handleCloseBtnClick}>
+			<S.ModalContainer>
+				<S.ModalWrapper>
+					<S.WateringImgWrapper>
+						<S.WateringImg src={WateringIcon} alt="" />
+					</S.WateringImgWrapper>
+
+					<S.MessageTitle>물 주기 완료!</S.MessageTitle>
+
+					<S.MessageDescWrapper>
+						<p>따듯한 메시지를 무사히 전달했어요.</p>
+						<p>덕분에 나무가 한 뼘 자라날 수 있게 되었어요!</p>
+					</S.MessageDescWrapper>
+
+					<S.ConfirmBtnWrapper>
+						<Button type="button" bgColor="primary" fontWeight="bold" onClick={handleCloseBtnClick}>
+							닫기
+						</Button>
+					</S.ConfirmBtnWrapper>
+				</S.ModalWrapper>
+			</S.ModalContainer>
+		</ModalFrame>
+	);
+};
+
+export default SuccessModal;

--- a/src/components/shared/Modal/type.ts
+++ b/src/components/shared/Modal/type.ts
@@ -1,8 +1,8 @@
-export type ModalBackDropStyledPropsType = {
+export type StyledProps = {
 	show: boolean;
 };
 
-export type ModalFramePropsType = {
+export type Props = {
 	children: React.ReactNode;
 	onModal: boolean;
 	setOnModal: (state: boolean) => void;

--- a/src/components/shared/index.tsx
+++ b/src/components/shared/index.tsx
@@ -1,3 +1,6 @@
 export { default as Routers } from './Routers';
 export { default as MessageTopMenu } from './MessageTopMenu/MessageTopMenu';
 export { default as MenuButton } from './MenuButton/MenuButton';
+export { default as MovingFolderModal } from './Modal/MovingFolderModal';
+export { default as SuccessModal } from './Modal/SuccessModal';
+export { default as SideDrawer } from './Modal/SideDrawer';

--- a/src/pages/MessageSender/MessageSender.styled.ts
+++ b/src/pages/MessageSender/MessageSender.styled.ts
@@ -1,24 +1,24 @@
 import styled from '@emotion/styled';
 
-export const MessageSenderContainer = styled.main`
+export const MessageSenderContainer = styled.form`
 	padding: 96px 0 30px 0;
 `;
 
-export const TopContainer = styled.div`
+export const TopWrapper = styled.div`
 	display: flex;
 	justify-content: space-between;
 	margin: 0 32px 0 32px;
 `;
 
-export const MessageInputContainer = styled.div`
+export const MessageInputWrapper = styled.div`
 	margin: 46px 32px 0 32px;
 `;
 
-export const AnonymousCheckBoxContainer = styled.div`
+export const AnonymousCheckBoxWrapper = styled.div`
 	margin-top: 33px;
 `;
 
-export const ButtonContainer = styled.div`
+export const ButtonWrapper = styled.div`
 	display: flex;
 	gap: 14px;
 	margin: 36px 32px 0 32px;

--- a/src/pages/MessageSender/index.tsx
+++ b/src/pages/MessageSender/index.tsx
@@ -1,16 +1,31 @@
-import React, { useState } from 'react';
+import React, { FormEvent, FormEventHandler, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './MessageSender.styled';
 import { RecipientName, FolderSelect, MessageInput, AnonymousCheckBox } from '@/components/features/MessageSender';
 import Button from '@/components/shared/Button';
+import { SuccessModal } from '@/components/shared';
 
 const MessageSender = () => {
 	const navigate = useNavigate();
 	const [recipientName, setRecipientName] = useState('나에게');
 	const [checkAnonymous, setCheckAnonymous] = useState(false);
+	const [isSucceedSendMessage, setIsSucceedSendMessage] = useState(false);
 
 	const onToggleCheckAnonymous = () => {
 		setCheckAnonymous(() => !checkAnonymous);
+	};
+
+	const handleSubmitMessage = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+
+		try {
+			// 메시지 작성 정보 POST 전송
+
+			// 정보가 잘 보내졌으면, 완료 모달 ON
+			setIsSucceedSendMessage(true);
+		} catch (error) {
+			// 에러 처리
+		}
 	};
 
 	const onGoBackClick = () => {
@@ -18,28 +33,32 @@ const MessageSender = () => {
 	};
 
 	return (
-		<S.MessageSenderContainer>
-			<S.TopContainer>
+		<S.MessageSenderContainer onSubmit={handleSubmitMessage}>
+			<S.TopWrapper>
 				<RecipientName name={recipientName} />
 				<FolderSelect />
-			</S.TopContainer>
+			</S.TopWrapper>
 
-			<S.MessageInputContainer>
+			<S.MessageInputWrapper>
 				<MessageInput />
-			</S.MessageInputContainer>
+			</S.MessageInputWrapper>
 
-			<S.AnonymousCheckBoxContainer>
+			<S.AnonymousCheckBoxWrapper>
 				<AnonymousCheckBox checked={checkAnonymous} handleToggleChecked={onToggleCheckAnonymous} />
-			</S.AnonymousCheckBoxContainer>
+			</S.AnonymousCheckBoxWrapper>
 
-			<S.ButtonContainer>
-				<Button type="button" bgColor="normal" onClick={onGoBackClick}>
+			<S.ButtonWrapper>
+				<Button type="button" bgColor="normal" fontWeight="medium" onClick={onGoBackClick}>
 					뒤로가기
 				</Button>
-				<Button type="submit" bgColor="primary" onClick={() => console.log('물 주기 API POST Go !')}>
+				<Button type="submit" bgColor="primary" fontWeight="bold">
 					물 주기
 				</Button>
-			</S.ButtonContainer>
+			</S.ButtonWrapper>
+
+			{isSucceedSendMessage && (
+				<SuccessModal isSucceedSendMessage={isSucceedSendMessage} handleCloseBtnClick={onGoBackClick} />
+			)}
 		</S.MessageSenderContainer>
 	);
 };


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#46 

### 💡 필요한 후속작업이 있어요.

- 현재는 UI 렌더링만 확인하기 위해 API 를 붙이지 않았고 `물 주기` 버튼을 누르면 물 주기 완료 모달이 바로 나타납니다. 
- 이후 물 주기 POST API 를 붙이고, 결과에 따라 모달 창이 나오는 방향으로 변경할 것 입니다.

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.