### PR TITLE
[#60] Feat: 메시지함 사이드바 유저 프로필 부분 API 데이터로 연결

### DIFF
--- a/src/components/shared/Modal/SideDrawer/SideDrawer.type.ts
+++ b/src/components/shared/Modal/SideDrawer/SideDrawer.type.ts
@@ -5,9 +5,6 @@ export type StyledProps = {
 };
 
 export type Props = {
-	username: string;
-	email: string;
-	profileImg: string;
 	handleFolderDeleteAlertModalToggle: (state: 'open' | 'close') => void;
 	onModal: boolean;
 	setOnModal: (state: boolean) => void;

--- a/src/components/shared/Modal/SideDrawer/index.tsx
+++ b/src/components/shared/Modal/SideDrawer/index.tsx
@@ -6,11 +6,10 @@ import TreeFolderItem from './TreeFolderItem';
 import EditFolderMoreModal from './EditFolderMoreModal';
 import Default_Profile_Img from '@/assets/images/noticeTree/alert_bee.svg';
 import { Props } from './SideDrawer.type';
+import { useRecoilValue } from 'recoil';
+import { myInfoState } from '@/stores/user';
 
 const SideDrawer = ({
-	username,
-	email,
-	profileImg,
 	onModal,
 	setOnModal,
 	onEditMoreModal,
@@ -19,6 +18,8 @@ const SideDrawer = ({
 	handleEditMoreModalClose,
 	handleFolderDeleteAlertModalToggle,
 }: Props) => {
+	const myInfo = useRecoilValue(myInfoState);
+
 	return (
 		<ModalFrame onModal={onModal} setOnModal={setOnModal}>
 			<S.SideDrawerContainer show={onModal}>
@@ -36,11 +37,11 @@ const SideDrawer = ({
 				<S.ThumbnailWrapper>
 					<S.ThumbnailBox>
 						<div>
-							<img src={profileImg || Default_Profile_Img} alt="프로필" />
+							<img src={myInfo?.userImage || Default_Profile_Img} alt="프로필" />
 						</div>
 						<div>
-							<h2>{username || '닉네임'}의 메시지함</h2>
-							<span>{email || 'abcde@email.com'}</span>
+							<h2>{myInfo?.nickname || '게스트'}의 메시지함</h2>
+							<span>{myInfo?.email || 'guest@email.com'}</span>
 						</div>
 					</S.ThumbnailBox>
 				</S.ThumbnailWrapper>

--- a/src/pages/MessageBox/index.tsx
+++ b/src/pages/MessageBox/index.tsx
@@ -232,9 +232,6 @@ const MessageBox = () => {
 			)}
 
 			<SideDrawer
-				username="username"
-				email="string"
-				profileImg="string"
 				onModal={openedDrawer}
 				setOnModal={onToggleOpenDrawer}
 				onEditMoreModal={onEditMoreModal}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#60 

로그인 시에 전역 상태로 저장된 데이터로만 변경한 것이라 크게 변경사항 없습니다.

<br><br>


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.