### PR TITLE
[#86] Fix: 나무 편집 treeId Parameter 받아오는 로직 수정

### DIFF
--- a/src/components/features/Forest/TreeAddForm/index.tsx
+++ b/src/components/features/Forest/TreeAddForm/index.tsx
@@ -16,6 +16,7 @@ const TreeAddForm = () => {
 	const navigate = useNavigate();
 	const { treeId } = useParams();
 
+	console.log(treeId);
 	const userId = useRecoilValue(myInfoState);
 
 	const { data: trees } = useQuery<Folder[] | undefined>('getForest', () => getForest(userId?.id), {

--- a/src/components/features/Forest/TreeAddForm/index.tsx
+++ b/src/components/features/Forest/TreeAddForm/index.tsx
@@ -16,7 +16,6 @@ const TreeAddForm = () => {
 	const navigate = useNavigate();
 	const { treeId } = useParams();
 
-	console.log(treeId);
 	const userId = useRecoilValue(myInfoState);
 
 	const { data: trees } = useQuery<Folder[] | undefined>('getForest', () => getForest(userId?.id), {
@@ -53,8 +52,6 @@ const TreeAddForm = () => {
 
 	const handleSubmitEditedTreeInfo = (event: React.FormEvent) => {
 		event.preventDefault();
-
-		console.log(treeName, selectedFruit);
 
 		if (treeId) {
 			treeUpdateMutation.mutate({ treeId: Number(treeId), name: treeName, fruitType: selectedFruit }); //

--- a/src/components/shared/Modal/SideDrawer/SideDrawer.type.ts
+++ b/src/components/shared/Modal/SideDrawer/SideDrawer.type.ts
@@ -6,6 +6,7 @@ export type StyledProps = {
 };
 
 export type Props = {
+	checkedTreeId?: number;
 	trees: Folder[] | undefined;
 	onModal: boolean;
 	setOnModal: (state: boolean) => void;

--- a/src/components/shared/Modal/SideDrawer/index.tsx
+++ b/src/components/shared/Modal/SideDrawer/index.tsx
@@ -11,6 +11,7 @@ import { myInfoState } from '@/stores/user';
 import { TREE_SIZE_MAX } from '@/constants/forest';
 
 const SideDrawer = ({
+	checkedTreeId,
 	trees,
 	onModal,
 	setOnModal,
@@ -87,6 +88,7 @@ const SideDrawer = ({
 
 						{onEditMoreModal && (
 							<EditFolderMoreModal
+								treeId={checkedTreeId}
 								modalPosition={modalPosition}
 								onEditMoreModal={onEditMoreModal}
 								handleEditMoreModalClose={handleEditMoreModalClose}

--- a/src/pages/MessageBox/index.tsx
+++ b/src/pages/MessageBox/index.tsx
@@ -208,6 +208,7 @@ const MessageBox = () => {
 			</S.MessageListContainer>
 
 			<SideDrawer
+				checkedTreeId={checkedTreeId}
 				trees={trees}
 				onModal={openedDrawer}
 				setOnModal={onToggleOpenDrawer}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#86 

이전 나무 편집 페이지 작업물 PR 중에 해당 로직이 날라간 것 같아서 추가한 것 밖에 없습니다.
불필요한 console 도 제거했습니다. (하나의 커밋 단위로 하기에 좀 애매하긴 했습니다..ㅎ)


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.