### PR TITLE
[101] Chore : 나무 상세페이지 좌우 버튼 디자인 변경 및 사이드바 즐겨찾기 클릭시 버튼 닫힘 추가 

### DIFF
--- a/src/assets/images/trees/tree_left_button.svg
+++ b/src/assets/images/trees/tree_left_button.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="20" r="20" fill="white"/>
+<path d="M18.8379 27.0195L19.502 26.3555L14.3848 21.2773H26.8457V20.3594H14.3848L19.502 15.2422L18.8379 14.6172L12.6465 20.8086L18.8379 27.0195Z" fill="#8C8C8C"/>
+</svg>

--- a/src/assets/images/trees/tree_right_button.svg
+++ b/src/assets/images/trees/tree_right_button.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="20" r="20" fill="white"/>
+<path d="M21.1621 27.0195L27.3535 20.8086L21.1621 14.6172L20.498 15.2617L25.6152 20.3594H13.1543V21.2773H25.6152L20.498 26.375L21.1621 27.0195Z" fill="#8C8C8C"/>
+</svg>

--- a/src/components/shared/Modal/SideDrawer/index.tsx
+++ b/src/components/shared/Modal/SideDrawer/index.tsx
@@ -65,7 +65,7 @@ const SideDrawer = ({ onModal, setOnModal }: Props) => {
 						</Link>
 					</S.MessageFilterItem>
 					<S.MessageFilterItem>
-						<Link to={'/messages/favorite'}>즐겨 찾기</Link>
+						<Link to={'/messages/favorite'} onClick={() => setOnModal(false)}>즐겨 찾기</Link>
 					</S.MessageFilterItem>
 				</S.MessageFilterList>
 

--- a/src/hooks/useDrawer.ts
+++ b/src/hooks/useDrawer.ts
@@ -40,10 +40,6 @@ const useDrawer = ({ onToggleOpenDrawer }: useDrawerProps) => {
 		treeDeleteMutation.mutate(checkedTreeId);
 	};
 
-	/**
-	 *
-	 * event.currentTarget이 null로 들어옵니다.
-	 */
 	const handleEditMoreModalOpen = (event: React.MouseEvent<HTMLElement>) => {
 		const closest = event.currentTarget.closest('li') as HTMLLIElement;
 		const rect = closest.getBoundingClientRect();

--- a/src/pages/TreeDetail/TreeDetail.styled.ts
+++ b/src/pages/TreeDetail/TreeDetail.styled.ts
@@ -11,6 +11,7 @@ export const TemporaryWrapper = styled.div`
 		${({ theme }) => theme.colors.bt_white} 100%
 	);
 `;
+
 export const TreeDetailTextWrapper = styled.div`
 	width: 100%;
 	display: flex;
@@ -37,23 +38,21 @@ export const TreeDetailMainText = styled.p`
 		margin-top: 10px;
 	}
 `;
+
 export const Button = styled.button`
-	background: ${({ theme }) => theme.colors.bt_yellow[50]};
-	width: 50px;
-	height: 50px;
-	border-radius: 50%;
-	border: none;
-
 	position: absolute;
-	top: 50%;
+	top: 127px;
 
-	font-size: ${({ theme }) => theme.fontSize.f18};
-	font-weight: ${({ theme }) => theme.fontWeight.strongBold};
+	background: none;
+
+	border: none;
 `;
+
 export const PrevButton = styled(Button)`
 	left: 0;
 	margin-left: 10px;
 `;
+
 export const NextButton = styled(Button)`
 	right: 0;
 	margin-right: 10px;

--- a/src/pages/TreeDetail/index.tsx
+++ b/src/pages/TreeDetail/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Clouds, Tree, MessageBox, WateringButton } from '@/components/features/NoticeTree';
 import * as S from './TreeDetail.styled';
-
+import LeftButton from '@/assets/images/trees/tree_left_button.svg';
+import RightButton from '@/assets/images/trees/tree_right_button.svg';
 import useTreeDetail from './useTreeDetail';
 const TreeDetail = () => {
 	const {
@@ -26,20 +27,25 @@ const TreeDetail = () => {
 					</S.TreeDetailMainText>
 					<span>맺혀 있는 열매 : {treeDetailInfo?.messages.length}개</span>
 				</S.TreeDetailTextWrapper>
+
 				<Tree updateReadMessageHandler={updateReadMessageHandler} messages={treeMessages ? treeMessages : null} />
 
 				{showMessage && (
 					<MessageBox selectedMessage={selectedMessage} showMessageHandler={() => setShowMessage(false)} />
 				)}
 
+				<WateringButton treeId={treeId} />
+
 				{treeDetailInfo?.prevId !== 0 && (
-					<S.PrevButton onClick={() => moveTree(treeDetailInfo?.prevId)}>{'<'}</S.PrevButton>
+					<S.PrevButton>
+						<img src={LeftButton} onClick={() => moveTree(treeDetailInfo?.prevId)} alt="move to prev tree" />
+					</S.PrevButton>
 				)}
 				{treeDetailInfo?.nextId !== 0 && (
-					<S.NextButton onClick={() => moveTree(treeDetailInfo?.nextId)}>{'>'}</S.NextButton>
+					<S.NextButton>
+						<img src={RightButton} onClick={() => moveTree(treeDetailInfo?.nextId)} alt="move to next tree" />
+					</S.NextButton>
 				)}
-
-				<WateringButton treeId={treeId} />
 			</S.TemporaryWrapper>
 		</>
 	);


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 나무 상세페이지 좌우 버튼 디자인 변경 
- 사이드바 즐겨찾기 클릭시 버튼 닫힘 추가 


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
