### PR TITLE
[#23][#65] Feat : 로그인 상태 확인 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,15 +8,15 @@ import { myInfoState } from '@/stores/user';
 const App = () => {
 	const setMyInfo = useSetRecoilState(myInfoState);
 
-	const handleCheckIsLoggedIn = useCallback(async () => {
-		const result = await checkMyInfo();
+	const handleCheckMyInfo = useCallback(async () => {
+		const response = await checkMyInfo();
 
-		setMyInfo(result);
+		setMyInfo(response?.payload);
 	}, [setMyInfo]);
 
 	useEffect(() => {
-		handleCheckIsLoggedIn();
-	}, [handleCheckIsLoggedIn]);
+		handleCheckMyInfo();
+	}, [handleCheckMyInfo]);
 
 	return (
 		<Layout>

--- a/src/apis/users.ts
+++ b/src/apis/users.ts
@@ -8,12 +8,12 @@ export const checkMyInfo = async () => {
 	} = API_URL;
 
 	try {
-		const { payload } = await requester<UserInfo>({
+		const response = await requester<UserInfo>({
 			method: GET,
 			url: info,
 		});
 
-		return payload;
+		return response;
 	} catch (error) {
 		// 에러 핸들링
 	}

--- a/src/components/features/MyPage/MyContents/MyContents.tsx
+++ b/src/components/features/MyPage/MyContents/MyContents.tsx
@@ -3,11 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { logout } from '@/apis/auth';
 import { RESPONSE_SUCCESS_OK } from '@/constants/api';
 import * as S from './MyContents.styled';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { myInfoState } from '@/stores/user';
 
 const MyContents = () => {
-	const setMyInfo = useSetRecoilState(myInfoState);
+	const [myInfo, setMyInfo] = useRecoilState(myInfoState);
 	const navigate = useNavigate();
 
 	const handleClickLogoutButton = async () => {
@@ -19,10 +19,16 @@ const MyContents = () => {
 		}
 	};
 
+	const DOMAIN_URL = 'http://localhost:3000';
+
+	const handleCopyUrlToClipBoard = async () => {
+		await navigator.clipboard.writeText(`${DOMAIN_URL}/forest/${myInfo?.id}`);
+	};
+
 	return (
 		<S.MyContentsContainer>
 			<S.MyMenuLink to="/mypage/edit">프로필 수정하기</S.MyMenuLink>
-			<S.MyMenuButton type="button" color="primary">
+			<S.MyMenuButton type="button" color="primary" onClick={handleCopyUrlToClipBoard}>
 				Url 주소 복사하기
 			</S.MyMenuButton>
 			<S.MyMenuButton type="button" color="grey" onClick={handleClickLogoutButton}>

--- a/src/pages/Login/useLogin.ts
+++ b/src/pages/Login/useLogin.ts
@@ -59,8 +59,8 @@ const useLogin = () => {
 		if (status === RESPONSE_SUCCESS_CREATED) {
 			navigate('/');
 
-			const result = await checkMyInfo();
-			setMyInfo(result);
+			const response = await checkMyInfo();
+			setMyInfo(response?.payload);
 		}
 	}, [location, navigate, setMyInfo]);
 

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MyInfo, MyContents } from '@/components/features/MyPage';
 import * as S from './MyPage.styled';
 import ServicePolicy from '@/components/features/MyPage/ServicePolicy';
+import withAuth from '@/utils/HOC/withAuth';
 
 const MyPage = () => {
 	return (
@@ -15,4 +16,4 @@ const MyPage = () => {
 	);
 };
 
-export default MyPage;
+export default withAuth(MyPage);

--- a/src/pages/MyPage/ProfileEdit/index.tsx
+++ b/src/pages/MyPage/ProfileEdit/index.tsx
@@ -7,6 +7,7 @@ import { myInfoState } from '@/stores/user';
 import useInput from '@/hooks/useInput';
 import { editProfile } from '@/apis/users';
 import { RESPONSE_SUCCESS_OK } from '@/constants/api';
+import withAuth from '@/utils/HOC/withAuth';
 
 const ProfileEdit = () => {
 	const [myInfo, setMyInfo] = useRecoilState(myInfoState);
@@ -53,4 +54,4 @@ const ProfileEdit = () => {
 	);
 };
 
-export default ProfileEdit;
+export default withAuth(ProfileEdit);

--- a/src/utils/HOC/withAuth.tsx
+++ b/src/utils/HOC/withAuth.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { checkMyInfo } from '@/apis/users';
+import { RESPONSE_SUCCESS_OK } from '@/constants/api';
+
+const withAuth = (Component: any) => {
+	const AuthenticatedComponent = () => {
+		const navigate = useNavigate();
+
+		const [isAllowed, setIsAllowed] = useState(false);
+
+		const handleCheckIsLoggedIn = async () => {
+			try {
+				const response = await checkMyInfo();
+
+				if (response?.status === RESPONSE_SUCCESS_OK) {
+					setIsAllowed(true);
+				} else {
+					navigate('/login', {
+						replace: true,
+					});
+				}
+			} catch (error) {
+				navigate('/login', {
+					replace: true,
+				});
+			}
+		};
+
+		useEffect(() => {
+			handleCheckIsLoggedIn();
+		}, []);
+
+		return isAllowed ? <Component /> : <></>;
+	};
+
+	return AuthenticatedComponent;
+};
+
+export default withAuth;


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- #65 
- #23 

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 로그인 상태를 확인하는 HOC 가 추가되었습니다.

<br><br>

### 💡 필요한 후속작업이 있어요.

- 여러 방법을 시도해봤는데 이렇게 HOC 로 각 페이지 컴포넌트를 감싸는 것이 가장 잘 작동하고 많이 사용하고 있었습니다.
- 각 페이지가 로그인이 필요한지는 맡으신 분들이 잘 아시기도 하고,
작업 중이신 페이지와 충돌이 날 수도 있을 것 같아서 일단 제가 맡은 마이페이지 쪽만 적용해두었습니다!
혹시 문제 있으시면 말씀해주시고 이후 적용부탁드립니다~
- 나중에 로딩 화면이 생기면 HOC 에서 `isAllowed === false` 일 때 보이도록 추가할 수 있을 것 같습니다.

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
