### PR TITLE
[#105] Fix: 클라이언트 - 서버 프로토콜 차이 문제, 임시 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist
 .yarn/install-state.gz
 
 .env
+.env.*
 
 .DS_Store

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
 		<title>App</title>
 
 		<link href="https://webfontworld.github.io/pretendard/Pretendard.css" rel="stylesheet" />


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#105 

`클라이언트(https) <-> 서버(http)` 인 상황에서 서버에서 ssl 설정이 안되어서 강제로 프로토콜이 맞게 작업하는 임시방편 방법이 있기에 적용해본 것 입니다.

해당 PR 을 받으면 index.html 에 추가된 메타 태그 때문에, 정상적으로 API Request 작동하지 않을 수 있습니다.
그 때는, 로컬에 변경된 index.html 파일의 meta 태그를 지우시면 정상 작동 될 것 입니다.

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.