### PR TITLE
[#111] Fix: day.js 라이브러리 Build 시 Cannot call a namespace 해결

### DIFF
--- a/src/components/features/MessageBox/MessageContent/index.tsx
+++ b/src/components/features/MessageBox/MessageContent/index.tsx
@@ -3,7 +3,7 @@ import LikeIcon from '@/assets/images/messages/like_star.svg';
 import BeeIcon from '@/assets/images/messages/message_bee.svg';
 import StarIcon from '@/assets/images/messages/star.svg';
 import { MessageCheckBox } from '@/components/features/MessageBox';
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
 import React from 'react';
 import { useMutation, useQueryClient } from 'react-query';


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#111 

`day.js` 라이브러리 import 방식을 namespace import 방식을 사용하신 것 같습니다.
이 경우 배포 환경에서 해당 라이브러리 네임스페이스를 찾지 못해서 번들 과정에서 포함되지 않는 것 같습니다.
default import 방식으로 해당 라이브러리 특정 버전 부터 가능해졌다고 하는 것 같습니다. 참고 링크 걸어놓겠습니다. @leechoiswim1 

<br />

참고
+ https://stackoverflow.com/questions/54184342/importing-dayjs-in-ng-library-outputs-namespace-error

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.