### PR TITLE
[#97] fix : 비로그인시 물주기, 나무숲 조회 구분 기능을 위한 레이아웃 퍼블릭/프라이빗 구분

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useEffect } from 'react';
-import { Routers } from '@/components/shared';
-import { Layout } from '@/components/layout';
 import { checkMyInfo } from '@/apis/users';
-import { useSetRecoilState } from 'recoil';
+import { Routers } from '@/components/shared';
 import { myInfoState } from '@/stores/user';
+import React, { useCallback, useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
 
 const App = () => {
 	const setMyInfo = useSetRecoilState(myInfoState);
@@ -18,11 +17,7 @@ const App = () => {
 		handleCheckMyInfo();
 	}, [handleCheckMyInfo]);
 
-	return (
-		<Layout>
-			<Routers />
-		</Layout>
-	);
+	return <Routers />;
 };
 
 export default App;

--- a/src/apis/forest.ts
+++ b/src/apis/forest.ts
@@ -1,7 +1,6 @@
 import API_URL, { DELETE, GET, POST, PUT } from '@/constants/api';
+import { Folder, TreeDetail, TreeDetailParam } from '@/types/forest';
 import { requester } from './requester';
-import { Folder } from '@/types/forest';
-import { TreeDetailParam, Param, TreeDetail } from '@/types/forest';
 
 export const postTree = async ({ name, fruitType }: { name: string; fruitType?: string }) => {
 	const {
@@ -23,7 +22,7 @@ export const postTree = async ({ name, fruitType }: { name: string; fruitType?: 
 	}
 };
 
-export const getForest = async (userId?: number) => {
+export const getForest = async (userId?: string | number | undefined) => {
 	const {
 		forest: { index },
 	} = API_URL;

--- a/src/apis/forest.ts
+++ b/src/apis/forest.ts
@@ -1,5 +1,5 @@
 import API_URL, { DELETE, GET, POST, PUT } from '@/constants/api';
-import { Folder, TreeDetail, TreeDetailParam } from '@/types/forest';
+import { ForestTrees, TreeDetail, TreeDetailParam } from '@/types/forest';
 import { requester } from './requester';
 
 export const postTree = async ({ name, fruitType }: { name: string; fruitType?: string }) => {
@@ -28,7 +28,7 @@ export const getForest = async (userId?: string | number | undefined) => {
 	} = API_URL;
 
 	try {
-		const response = await requester<Folder[]>({
+		const response = await requester<ForestTrees>({
 			method: GET,
 			url: `${index}?userId=${userId}`,
 		});

--- a/src/apis/requester.ts
+++ b/src/apis/requester.ts
@@ -1,5 +1,5 @@
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { getStorageItem, storageAccessKey } from '@/utils/local-storage';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 const createAxiosInstance = () => {
 	const base = axios.create({
@@ -43,12 +43,18 @@ const axiosInstance = createAxiosInstance();
 export async function requester<Payload>(option: AxiosRequestConfig) {
 	const accessToken = getStorageItem(storageAccessKey);
 
-	const response: AxiosResponse<Payload> = await axiosInstance({
-		headers: {
-			Authorization: accessToken ? `Bearer ${accessToken}` : '',
-		},
-		...option,
-	});
+	const response: AxiosResponse<Payload> = await axiosInstance(
+		accessToken
+			? {
+					headers: {
+						Authorization: `Bearer ${accessToken}`,
+					},
+					...option,
+			  }
+			: {
+					...option,
+			  },
+	);
 
 	return {
 		status: response.status,

--- a/src/components/features/Forest/TreeAddForm/index.tsx
+++ b/src/components/features/Forest/TreeAddForm/index.tsx
@@ -1,17 +1,18 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import * as S from './TreeAddForm.styled';
-import TreeNameInput from './Input/TreeNameInput';
-import TreeFruitInput from './Input/TreeFruitInput';
-import Button from '@/components/shared/Button';
+import { getForest, postTree, updateTree } from '@/apis/forest';
 import BeeIcon from '@/assets/images/noticeTree/alert_bee.png';
-import { FRUITS, FRUIT_RENDER_POSITION } from '@/constants/forest';
-import { useQuery, useMutation } from 'react-query';
-import { Folder } from '@/types/forest';
-import { postTree, getForest, updateTree } from '@/apis/forest';
-import { useRecoilValue } from 'recoil';
-import { myInfoState } from '@/stores/user';
+import { Layout } from '@/components/layout';
+import Button from '@/components/shared/Button';
 import Toast from '@/components/shared/Toast';
+import { FRUITS, FRUIT_RENDER_POSITION } from '@/constants/forest';
+import { myInfoState } from '@/stores/user';
+import { Folder } from '@/types/forest';
+import React, { useEffect, useState } from 'react';
+import { useMutation, useQuery } from 'react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import TreeFruitInput from './Input/TreeFruitInput';
+import TreeNameInput from './Input/TreeNameInput';
+import * as S from './TreeAddForm.styled';
 
 const TreeAddForm = () => {
 	const navigate = useNavigate();
@@ -94,69 +95,71 @@ const TreeAddForm = () => {
 	}, [treeId]);
 
 	return (
-		<S.Container>
-			<S.Background />
-			<S.TreeAddForm onSubmit={handleSubmitEditedTreeInfo}>
-				<S.HelperMessageContainer>
-					<S.HelperBeeContainer>
-						<img src={BeeIcon} alt="가이드 메시지 꿀벌" />
-					</S.HelperBeeContainer>
-					<S.HelperBeeMessage>
-						<p>열매 나무를 편집하시나요?</p>
-						<p>나무의 이름도 바꿔보세요.</p>
-					</S.HelperBeeMessage>
-				</S.HelperMessageContainer>
+		<Layout path={'private'}>
+			<S.Container>
+				<S.Background />
+				<S.TreeAddForm onSubmit={handleSubmitEditedTreeInfo}>
+					<S.HelperMessageContainer>
+						<S.HelperBeeContainer>
+							<img src={BeeIcon} alt="가이드 메시지 꿀벌" />
+						</S.HelperBeeContainer>
+						<S.HelperBeeMessage>
+							<p>열매 나무를 편집하시나요?</p>
+							<p>나무의 이름도 바꿔보세요.</p>
+						</S.HelperBeeMessage>
+					</S.HelperMessageContainer>
 
-				<S.TreeInputContainer>
-					<div>
-						<S.TreeNameInputWrapper>
-							<TreeNameInput
-								placeholder="새 폴더 이름을 입력하세요."
-								treeName={treeName}
-								onChangeTreeName={handleChangeTreeName}
-							/>
-						</S.TreeNameInputWrapper>
-
-						<S.TreeShapeContainer>
-							<S.TreeCircle>
-								{FRUIT_RENDER_POSITION.map((info) => {
-									return <S.Fruit key={info.id} src={getSelectedFruitImage()} alt={''} position={info.position} />;
-								})}
-							</S.TreeCircle>
-							<S.TreePole />
-						</S.TreeShapeContainer>
-					</div>
-
-					<S.TreeFruitListWrapper>
-						<S.TreeFruitList>
-							{FRUITS.map((fruit) => (
-								<TreeFruitInput
-									key={fruit.id}
-									fruit={fruit}
-									selected={fruit.value === selectedFruit}
-									onChangeSelectedFruit={handleChangeSelectedFruit}
+					<S.TreeInputContainer>
+						<div>
+							<S.TreeNameInputWrapper>
+								<TreeNameInput
+									placeholder="새 폴더 이름을 입력하세요."
+									treeName={treeName}
+									onChangeTreeName={handleChangeTreeName}
 								/>
-							))}
-						</S.TreeFruitList>
-					</S.TreeFruitListWrapper>
-				</S.TreeInputContainer>
+							</S.TreeNameInputWrapper>
 
-				<S.WarnningDescBox>
-					<p>※ 나무의 열매에 선택한 메시지가 랜덤하게 배정되며</p>
-					<p>임의로 열매의 위치를 선택할 수 없습니다.</p>
-				</S.WarnningDescBox>
+							<S.TreeShapeContainer>
+								<S.TreeCircle>
+									{FRUIT_RENDER_POSITION.map((info) => {
+										return <S.Fruit key={info.id} src={getSelectedFruitImage()} alt={''} position={info.position} />;
+									})}
+								</S.TreeCircle>
+								<S.TreePole />
+							</S.TreeShapeContainer>
+						</div>
 
-				<S.ButtonBox>
-					<Button type="button" width="156px" bgColor="normal" fontWeight="medium" onClick={handleGoBackClick}>
-						뒤로가기
-					</Button>
-					<Button type="submit" width="156px" bgColor="primary" fontWeight="bold">
-						저장하기
-					</Button>
-				</S.ButtonBox>
-			</S.TreeAddForm>
-			<Toast show={isToastVisible} message={formAlertMessage} onClose={() => setIsToastVisible(false)} />
-		</S.Container>
+						<S.TreeFruitListWrapper>
+							<S.TreeFruitList>
+								{FRUITS.map((fruit) => (
+									<TreeFruitInput
+										key={fruit.id}
+										fruit={fruit}
+										selected={fruit.value === selectedFruit}
+										onChangeSelectedFruit={handleChangeSelectedFruit}
+									/>
+								))}
+							</S.TreeFruitList>
+						</S.TreeFruitListWrapper>
+					</S.TreeInputContainer>
+
+					<S.WarnningDescBox>
+						<p>※ 나무의 열매에 선택한 메시지가 랜덤하게 배정되며</p>
+						<p>임의로 열매의 위치를 선택할 수 없습니다.</p>
+					</S.WarnningDescBox>
+
+					<S.ButtonBox>
+						<Button type="button" width="156px" bgColor="normal" fontWeight="medium" onClick={handleGoBackClick}>
+							뒤로가기
+						</Button>
+						<Button type="submit" width="156px" bgColor="primary" fontWeight="bold">
+							저장하기
+						</Button>
+					</S.ButtonBox>
+				</S.TreeAddForm>
+				<Toast show={isToastVisible} message={formAlertMessage} onClose={() => setIsToastVisible(false)} />
+			</S.Container>
+		</Layout>
 	);
 };
 

--- a/src/components/features/Forest/TreeList/TreeItem/index.tsx
+++ b/src/components/features/Forest/TreeList/TreeItem/index.tsx
@@ -1,17 +1,19 @@
-import React from 'react';
-import * as S from './TreeItem.styled';
-import { Link } from 'react-router-dom';
 import {
-	TreeShapeContainer,
+	Fruit,
 	TreeCircle,
 	TreePole,
-	Fruit,
+	TreeShapeContainer,
 } from '@/components/features/Forest/TreeAddForm/TreeAddForm.styled';
-import { FRUIT_RENDER_POSITION, FRUITS } from '@/constants/forest';
+import { FRUITS, FRUIT_RENDER_POSITION } from '@/constants/forest';
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+import * as S from './TreeItem.styled';
 import { Props } from './TreeItem.type';
 
 const TreeItem = ({ tree }: Props) => {
 	const { id, fruit, name } = tree;
+
+	const { userId } = useParams();
 
 	const getSelectedFruitImage = (fruitValue: React.SetStateAction<string | undefined>) => {
 		const selectedFruitObj = FRUITS.filter((fruit) => fruit.value === fruitValue)[0];
@@ -20,7 +22,7 @@ const TreeItem = ({ tree }: Props) => {
 
 	return (
 		<S.ItemWrapper>
-			<Link to={`/forest/tree/${id}`}>
+			<Link to={userId ? `/forest/tree/${id}/${userId}` : `/forest/tree/${id}`}>
 				<TreeShapeContainer>
 					<TreeCircle size="small">
 						{FRUIT_RENDER_POSITION.map((info) => {

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -1,22 +1,20 @@
-import React, { ReactNode } from 'react';
-import { Header, BottomNav, BackgroundArea } from '@/components/layout';
+import { BackgroundArea, BottomNav, Header } from '@/components/layout';
+import React from 'react';
 import * as S from './Layout.styled';
-import { useLocation } from 'react-router-dom';
 
 type Props = {
-	children: ReactNode;
+	path: string;
+	children: JSX.Element;
 };
 
-const Layout = ({ children }: Props) => {
-	const { pathname } = useLocation();
-
+const Layout = ({ children, path }: Props) => {
 	return (
 		<>
 			<BackgroundArea />
 			<S.AppContainer>
-				{pathname === '/login' || pathname === '/not-found' || pathname === '/' ? (
-					<S.LayoutContentWrapper>{children}</S.LayoutContentWrapper>
-				) : (
+				{path === 'public' && <S.LayoutContentWrapper>{children}</S.LayoutContentWrapper>}
+
+				{path === 'private' && (
 					<>
 						<Header />
 						<S.LayoutContentWrapper>{children}</S.LayoutContentWrapper>

--- a/src/components/layout/PublicBottomNav/PublicBottomNav.styled.ts
+++ b/src/components/layout/PublicBottomNav/PublicBottomNav.styled.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const BottomNavWrapper = styled.nav`
+	position: sticky;
+	bottom: 0;
+	width: 100%;
+	padding: 21px 60px 32px 60px;
+	background: ${({ theme }) => theme.colors.bt_white};
+	box-shadow: 0px -4px 5px rgba(0, 0, 0, 0.05);
+	border-radius: 20px 20px 0px 0px;
+`;

--- a/src/components/layout/PublicBottomNav/index.tsx
+++ b/src/components/layout/PublicBottomNav/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import * as S from './PublicBottomNav.styled';
+
+const PublicBottomNav = () => {
+	return <S.BottomNavWrapper />;
+};
+
+export default PublicBottomNav;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,5 @@
+export { default as BackgroundArea } from './BackgroundArea';
+export { default as BottomNav } from './BottomNav/BottomNav';
 export { default as Header } from './Header/Header';
 export { default as Layout } from './Layout/Layout';
-export { default as BottomNav } from './BottomNav/BottomNav';
-export { default as BackgroundArea } from './BackgroundArea';
+export { default as PublicBottomNav } from './PublicBottomNav';

--- a/src/components/shared/Routers.tsx
+++ b/src/components/shared/Routers.tsx
@@ -1,18 +1,19 @@
 import {
 	Forest,
+	Landing,
 	MessageBox,
 	MessageDetail,
 	MessageSender,
 	MyPage,
-	NoticeTree,
-	TreeDetail,
 	NotFound,
-	Landing,
+	NoticeTree,
+	PublicForest,
+	TreeDetail,
 } from '@/pages';
 import Login from '@/pages/Login';
 import ProfileEdit from '@/pages/MyPage/ProfileEdit';
 import React from 'react';
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import TreeAddForm from '../features/Forest/TreeAddForm';
 
 const Routers = () => {
@@ -22,7 +23,7 @@ const Routers = () => {
 			<Route path="/main-tree" element={<NoticeTree />} />
 			<Route path="/login" element={<Login />} />
 			<Route path="/forest" element={<Forest />} />
-			<Route path="/forest/:userId" element={<Forest />} />
+			<Route path="/forest/:userId" element={<PublicForest />} />
 			<Route path="/forest/tree/:treeId" element={<TreeDetail />} />
 			<Route path="/forest/edit" element={<TreeAddForm />} />
 			<Route path="/forest/edit/:treeId" element={<TreeAddForm />} />

--- a/src/components/shared/Routers.tsx
+++ b/src/components/shared/Routers.tsx
@@ -25,11 +25,13 @@ const Routers = () => {
 			<Route path="/forest" element={<Forest />} />
 			<Route path="/forest/:userId" element={<PublicForest />} />
 			<Route path="/forest/tree/:treeId" element={<TreeDetail />} />
+			<Route path="/forest/tree/:treeId/:treeUserId" element={<TreeDetail />} />
 			<Route path="/forest/edit" element={<TreeAddForm />} />
 			<Route path="/forest/edit/:treeId" element={<TreeAddForm />} />
 			<Route path="/mypage" element={<MyPage />} />
 			<Route path="/mypage/edit" element={<ProfileEdit />} />
 			<Route path="/message/edit" element={<MessageSender />} />
+			<Route path="/message/edit/:treeUserId/:treeOwner" element={<MessageSender />} />
 			<Route path="/message/edit/:treeId" element={<MessageSender />} />
 			<Route path="/messages" element={<MessageBox />} />
 			<Route path="/messages/:treeId" element={<MessageBox />} />

--- a/src/hooks/useDrawer.ts
+++ b/src/hooks/useDrawer.ts
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
-import { useRecoilValue } from 'recoil';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { myInfoState } from '@/stores/user';
 import { deleteTree, getForest } from '@/apis/forest';
-import { Folder } from '@/types/forest';
+import { myInfoState } from '@/stores/user';
+import { Folder, ForestTrees } from '@/types/forest';
+import React, { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
 interface useDrawerProps {
 	onToggleOpenDrawer: () => void;
@@ -15,11 +15,15 @@ const useDrawer = ({ onToggleOpenDrawer }: useDrawerProps) => {
 	const navigator = useNavigate();
 	const queryClient = useQueryClient();
 	const [checkedTreeId, setCheckedTreeId] = useState<number>();
+	const [trees, setTrees] = useState<Folder[] | undefined>(undefined);
 	const [onEditMoreModal, setOnEditMoreModal] = useState(false);
 	const [modalPosition, setModalPosition] = useState({ top: 0, left: 0 });
 	const [isOpenedFolderDeleteAlertModal, setIsOpenedFolderDeleteAlertModal] = useState(false);
 
-	const { data: trees } = useQuery<Folder[] | undefined>(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
+	const { data: treeInfo } = useQuery<ForestTrees | undefined>(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
+		onSuccess: () => {
+			setTrees(treeInfo?.responseDtoList);
+		},
 		enabled: !!myInfo,
 	});
 

--- a/src/pages/Forest/index.tsx
+++ b/src/pages/Forest/index.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useQuery } from 'react-query';
-import * as S from './Forest.styled';
-import MessageChip from '@/components/shared/Chip/MessageChip';
-import Button from '@/components/shared/Button';
+import { getForest } from '@/apis/forest';
 import TreeList from '@/components/features/Forest/TreeList';
+import { Layout } from '@/components/layout';
+import Button from '@/components/shared/Button';
+import MessageChip from '@/components/shared/Chip/MessageChip';
 import { Folder } from '@/types/forest';
+import withAuth from '@/utils/HOC/withAuth';
+import React from 'react';
+import { useQuery } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { myInfoState } from '../../stores/user';
-import { getForest } from '@/apis/forest';
+import * as S from './Forest.styled';
 
 const Forest = () => {
 	const navigate = useNavigate();
@@ -20,18 +22,20 @@ const Forest = () => {
 	});
 
 	return (
-		<S.TreesContainer>
-			<MessageChip message="오늘 하루도 고생한 우리에게 따듯한 칭찬을 남겨보세요!" />
+		<Layout path="private">
+			<S.TreesContainer>
+				<MessageChip message="오늘 하루도 고생한 우리에게 따듯한 칭찬을 남겨보세요!" />
 
-			<S.TreeListBox>{folders && <TreeList trees={folders} />}</S.TreeListBox>
+				<S.TreeListBox>{folders && <TreeList trees={folders} />}</S.TreeListBox>
 
-			<S.ButtonBox>
-				<Button type="button" bgColor="primary" onClick={() => navigate('/message/edit')}>
-					나무에 물 주기
-				</Button>
-			</S.ButtonBox>
-		</S.TreesContainer>
+				<S.ButtonBox>
+					<Button type="button" bgColor="primary" onClick={() => navigate('/message/edit')}>
+						나무에 물 주기
+					</Button>
+				</S.ButtonBox>
+			</S.TreesContainer>
+		</Layout>
 	);
 };
 
-export default Forest;
+export default withAuth(Forest);

--- a/src/pages/Forest/index.tsx
+++ b/src/pages/Forest/index.tsx
@@ -3,9 +3,9 @@ import TreeList from '@/components/features/Forest/TreeList';
 import { Layout } from '@/components/layout';
 import Button from '@/components/shared/Button';
 import MessageChip from '@/components/shared/Chip/MessageChip';
-import { Folder } from '@/types/forest';
+import { Folder, ForestTrees } from '@/types/forest';
 import withAuth from '@/utils/HOC/withAuth';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
@@ -17,16 +17,22 @@ const Forest = () => {
 
 	const myInfo = useRecoilValue(myInfoState);
 
-	const { data: folders } = useQuery<Folder[] | undefined>(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
+	const [treeFolders, setTreeFolders] = useState<Folder[] | undefined>(undefined);
+
+	const { data: folders } = useQuery<ForestTrees | undefined>(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
 		enabled: !!myInfo,
 	});
+
+	useEffect(() => {
+		folders && setTreeFolders(folders.responseDtoList);
+	}, [folders]);
 
 	return (
 		<Layout path="private">
 			<S.TreesContainer>
 				<MessageChip message="오늘 하루도 고생한 우리에게 따듯한 칭찬을 남겨보세요!" />
 
-				<S.TreeListBox>{folders && <TreeList trees={folders} />}</S.TreeListBox>
+				<S.TreeListBox>{folders && <TreeList trees={treeFolders} />}</S.TreeListBox>
 
 				<S.ButtonBox>
 					<Button type="button" bgColor="primary" onClick={() => navigate('/message/edit')}>

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react';
-import * as S from './Landing.styled';
-import PrimaryLogoIcon from '@/assets/images/layout/betree_logo.svg';
 import LandingTreeImg from '@/assets/images/landing/landing_tree.png';
-import { useRecoilValue } from 'recoil';
+import PrimaryLogoIcon from '@/assets/images/layout/betree_logo.svg';
+import { Layout } from '@/components/layout';
 import { myInfoState } from '@/stores/user';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import * as S from './Landing.styled';
 
 const Landing = () => {
 	const userInfo = useRecoilValue(myInfoState);
@@ -17,29 +18,31 @@ const Landing = () => {
 	}, [userInfo, navigator]);
 
 	return (
-		<S.Container>
-			<S.LandingLogoWrapper>
-				<S.LandingLogo src={PrimaryLogoIcon} alt="" />
-			</S.LandingLogoWrapper>
+		<Layout path="public">
+			<S.Container>
+				<S.LandingLogoWrapper>
+					<S.LandingLogo src={PrimaryLogoIcon} alt="" />
+				</S.LandingLogoWrapper>
 
-			<S.LandingTitleWrapper>
-				<S.LandingImojiTitle>잘한다👏 자란다🌳</S.LandingImojiTitle>
-				<S.LandingTitle>자존감이 자라는 곳</S.LandingTitle>
-			</S.LandingTitleWrapper>
+				<S.LandingTitleWrapper>
+					<S.LandingImojiTitle>잘한다👏 자란다🌳</S.LandingImojiTitle>
+					<S.LandingTitle>자존감이 자라는 곳</S.LandingTitle>
+				</S.LandingTitleWrapper>
 
-			<S.LandingImgWrapper>
-				<S.LandingImg src={LandingTreeImg} alt="" />
-			</S.LandingImgWrapper>
+				<S.LandingImgWrapper>
+					<S.LandingImg src={LandingTreeImg} alt="" />
+				</S.LandingImgWrapper>
 
-			<S.LandingDescWrapper>
-				<S.LandingDesc>칭찬의 장벽을 낮추고, 자존감을 높이는 Betree입니다.</S.LandingDesc>
-				<S.LandingDesc>칭찬하고 칭찬 받으며 나만의 따뜻한 나무숲을 가꾸세요!</S.LandingDesc>
-			</S.LandingDescWrapper>
+				<S.LandingDescWrapper>
+					<S.LandingDesc>칭찬의 장벽을 낮추고, 자존감을 높이는 Betree입니다.</S.LandingDesc>
+					<S.LandingDesc>칭찬하고 칭찬 받으며 나만의 따뜻한 나무숲을 가꾸세요!</S.LandingDesc>
+				</S.LandingDescWrapper>
 
-			<S.AppStartButtonWrapper>
-				<S.AppStartButton to="/main-tree">Betree 시작하기</S.AppStartButton>
-			</S.AppStartButtonWrapper>
-		</S.Container>
+				<S.AppStartButtonWrapper>
+					<S.AppStartButton to="/main-tree">Betree 시작하기</S.AppStartButton>
+				</S.AppStartButtonWrapper>
+			</S.Container>
+		</Layout>
 	);
 };
 

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import BigTreeLogo from '@/assets/images/shared/big_tree_logo.svg';
 import KakaoLogin from '@/assets/images/login/kakao_login_large_wide@2x.png';
+import BigTreeLogo from '@/assets/images/shared/big_tree_logo.svg';
+import { Layout } from '@/components/layout';
+import React from 'react';
 import * as S from './Login.styled';
 import useLogin from './useLogin';
 
@@ -8,17 +9,19 @@ const Login = () => {
 	const handleClickLoginButton = useLogin();
 
 	return (
-		<S.LoginContainer>
-			<S.ServiceInfo>
-				<img src={BigTreeLogo} alt="" />
-				<p>칭찬 공유</p>
-				<p>아카이브 서비스, Betree</p>
-			</S.ServiceInfo>
+		<Layout path="public">
+			<S.LoginContainer>
+				<S.ServiceInfo>
+					<img src={BigTreeLogo} alt="" />
+					<p>칭찬 공유</p>
+					<p>아카이브 서비스, Betree</p>
+				</S.ServiceInfo>
 
-			<S.KakaoLoginButton type="button" onClick={handleClickLoginButton}>
-				<img src={KakaoLogin} alt="카카오로 시작하기" />
-			</S.KakaoLoginButton>
-		</S.LoginContainer>
+				<S.KakaoLoginButton type="button" onClick={handleClickLoginButton}>
+					<img src={KakaoLogin} alt="카카오로 시작하기" />
+				</S.KakaoLoginButton>
+			</S.LoginContainer>
+		</Layout>
 	);
 };
 

--- a/src/pages/MessageBox/index.tsx
+++ b/src/pages/MessageBox/index.tsx
@@ -11,7 +11,7 @@ import { Layout } from '@/components/layout';
 import { DeleteAlertModal, ErrorToast, MovingFolderModal, SideDrawer, SmallAlertModal } from '@/components/shared';
 import { errorToastState, smallModalState } from '@/stores/modal';
 import { myInfoState } from '@/stores/user';
-import { Folder } from '@/types/forest';
+import { Folder, ForestTrees } from '@/types/forest';
 import { Message } from '@/types/message';
 import withAuth from '@/utils/HOC/withAuth';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -26,7 +26,7 @@ const MessageBox = () => {
 	const [errorToastText, setErrorToastText] = useRecoilState(errorToastState);
 	const myInfo = useRecoilValue(myInfoState);
 
-	const { data: folders } = useQuery<Folder[] | undefined>(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
+	const { data: treeInfo } = useQuery<ForestTrees | undefined>(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
 		enabled: !!myInfo,
 	});
 
@@ -191,11 +191,11 @@ const MessageBox = () => {
 		if (treeId === 'favorite' || !treeId) {
 			return;
 		}
-		if (folders && treeId) {
-			const idx = folders.findIndex((folder) => folder.id === Number(treeId));
-			setCurrentTree(folders[idx].name);
+		if (treeInfo && treeId) {
+			const idx = treeInfo.responseDtoList.findIndex((folder: Folder) => folder.id === Number(treeId));
+			setCurrentTree(treeInfo.responseDtoList[idx].name);
 		}
-	}, [folders, treeId]);
+	}, [treeInfo, treeId]);
 
 	useEffect(() => {
 		if (!checkMode) {

--- a/src/pages/MessageBox/index.tsx
+++ b/src/pages/MessageBox/index.tsx
@@ -7,17 +7,18 @@ import {
 	MessageContent,
 	MessageMenu,
 } from '@/components/features/MessageBox';
+import { Layout } from '@/components/layout';
 import { DeleteAlertModal, ErrorToast, MovingFolderModal, SideDrawer, SmallAlertModal } from '@/components/shared';
+import { errorToastState, smallModalState } from '@/stores/modal';
 import { myInfoState } from '@/stores/user';
 import { Folder } from '@/types/forest';
 import { Message } from '@/types/message';
+import withAuth from '@/utils/HOC/withAuth';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { smallModalState, errorToastState } from '@/stores/modal';
 import * as S from './MessageBox.styled';
-import withAuth from '@/utils/HOC/withAuth';
 
 const MessageBox = () => {
 	const { treeId } = useParams();
@@ -209,78 +210,80 @@ const MessageBox = () => {
 	}, [isMakingFruit]);
 
 	return (
-		<S.Wrapper>
-			{isMakingFruit ? (
-				<MakingFruitMenu
-					showCheckedMessages={showCheckedMessages}
-					setShowCheckedMessages={setShowCheckedMessages}
-					numberOfCheckedMessages={checkMessages.length}
-				/>
-			) : (
-				<MessageMenu
-					isEdit={isEdit}
-					editMakingToggleHandler={editMakingToggleHandler}
-					onToggleOpenDrawer={onToggleOpenDrawer}
-					onToggleMovingFolderModal={onClickMovingFolderButton}
-					deleteMessages={onClickDeleteButton}
-					treeName={currentTree}
-				/>
-			)}
-
-			<S.MessageListContainer checkMode={checkMode} isMakingFruit={isMakingFruit}>
-				{filteredList &&
-					filteredList.map((res, idx) => (
-						<div key={`message-box-message${res.id}`} ref={idx === filteredList.length - 1 ? lastItemRef : null}>
-							<MessageContent
-								key={`message-box-message${res.id}`}
-								message={res}
-								idx={idx}
-								checkMode={checkMode}
-								onToggleCheckMessage={onToggleCheckMessage}
-								checkMessages={checkMessages}
-								onToggleLike={onToggleLike}
-							/>
-						</div>
-					))}
-				{messageList?.length === 0 && <EmptyMessage treeId={treeId} />}
-
-				{checkMode && (
-					<BottomButtons
-						isEdit={isEdit}
-						isMakingFruit={isMakingFruit}
-						editMakingToggleHandler={editMakingToggleHandler}
-						checkMessages={checkMessages}
-						getMessageList={getMessageList}
-						setIsMakingFruit={setIsMakingFruit}
+		<Layout path="private">
+			<S.Wrapper>
+				{isMakingFruit ? (
+					<MakingFruitMenu
+						showCheckedMessages={showCheckedMessages}
 						setShowCheckedMessages={setShowCheckedMessages}
+						numberOfCheckedMessages={checkMessages.length}
+					/>
+				) : (
+					<MessageMenu
+						isEdit={isEdit}
+						editMakingToggleHandler={editMakingToggleHandler}
+						onToggleOpenDrawer={onToggleOpenDrawer}
+						onToggleMovingFolderModal={onClickMovingFolderButton}
+						deleteMessages={onClickDeleteButton}
+						treeName={currentTree}
 					/>
 				)}
-			</S.MessageListContainer>
 
-			{isMoving && (
-				<MovingFolderModal
-					isMoving={isMoving}
-					setIsEdit={setIsEdit}
-					onToggleMovingFolderModal={onToggleMovingFolderModal}
-					checkMessages={checkMessages}
-					getMessageList={getMessageList}
-				/>
-			)}
+				<S.MessageListContainer checkMode={checkMode} isMakingFruit={isMakingFruit}>
+					{filteredList &&
+						filteredList.map((res, idx) => (
+							<div key={`message-box-message${res.id}`} ref={idx === filteredList.length - 1 ? lastItemRef : null}>
+								<MessageContent
+									key={`message-box-message${res.id}`}
+									message={res}
+									idx={idx}
+									checkMode={checkMode}
+									onToggleCheckMessage={onToggleCheckMessage}
+									checkMessages={checkMessages}
+									onToggleLike={onToggleLike}
+								/>
+							</div>
+						))}
+					{messageList?.length === 0 && <EmptyMessage treeId={treeId} />}
 
-			{isOpenedMessageDeleteAlertModal && (
-				<DeleteAlertModal
-					deleteTargetType="message"
-					deleteTarget="메시지"
-					onAlertModal={isOpenedMessageDeleteAlertModal}
-					handleAlertModalToggle={() => setIsOpenedMessageDeleteAlertModal(false)}
-					handleTargetDelete={deleteMessageHandler}
-				/>
-			)}
+					{checkMode && (
+						<BottomButtons
+							isEdit={isEdit}
+							isMakingFruit={isMakingFruit}
+							editMakingToggleHandler={editMakingToggleHandler}
+							checkMessages={checkMessages}
+							getMessageList={getMessageList}
+							setIsMakingFruit={setIsMakingFruit}
+							setShowCheckedMessages={setShowCheckedMessages}
+						/>
+					)}
+				</S.MessageListContainer>
 
-			<SideDrawer onModal={openedDrawer} setOnModal={onToggleOpenDrawer} />
-			{smallModal && <SmallAlertModal />}
-			{errorToastText && <ErrorToast />}
-		</S.Wrapper>
+				{isMoving && (
+					<MovingFolderModal
+						isMoving={isMoving}
+						setIsEdit={setIsEdit}
+						onToggleMovingFolderModal={onToggleMovingFolderModal}
+						checkMessages={checkMessages}
+						getMessageList={getMessageList}
+					/>
+				)}
+
+				{isOpenedMessageDeleteAlertModal && (
+					<DeleteAlertModal
+						deleteTargetType="message"
+						deleteTarget="메시지"
+						onAlertModal={isOpenedMessageDeleteAlertModal}
+						handleAlertModalToggle={() => setIsOpenedMessageDeleteAlertModal(false)}
+						handleTargetDelete={deleteMessageHandler}
+					/>
+				)}
+
+				<SideDrawer onModal={openedDrawer} setOnModal={onToggleOpenDrawer} />
+				{smallModal && <SmallAlertModal />}
+				{errorToastText && <ErrorToast />}
+			</S.Wrapper>
+		</Layout>
 	);
 };
 

--- a/src/pages/MessageDetail/index.tsx
+++ b/src/pages/MessageDetail/index.tsx
@@ -3,15 +3,16 @@ import ArrowDownIcon from '@/assets/images/shared/arrow_down.svg';
 import ArrowUpIcon from '@/assets/images/shared/arrow_up.svg';
 import { MessageMenu } from '@/components/features/MessageBox';
 import { MessageDetailHeader } from '@/components/features/MessageDetail';
+import { Layout } from '@/components/layout';
 import { AlertModal, ErrorToast, MovingFolderModal, SideDrawer } from '@/components/shared';
+import { errorToastState } from '@/stores/modal';
 import { MessageDetailData } from '@/types/message';
-import React, { useEffect, useState } from 'react';
+import withAuth from '@/utils/HOC/withAuth';
+import React, { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
-import * as S from './MessageDetail.styled';
-import withAuth from '@/utils/HOC/withAuth';
 import { useRecoilState } from 'recoil';
-import { errorToastState } from '@/stores/modal';
+import * as S from './MessageDetail.styled';
 
 const MessageDetail = () => {
 	const navigate = useNavigate();
@@ -108,72 +109,74 @@ const MessageDetail = () => {
 	};
 
 	return (
-		<S.Wrapper>
-			<MessageMenu
-				isEdit={true}
-				onToggleMovingFolderModal={onToggleMovingFolderModal}
-				onToggleOpenDrawer={onToggleOpenDrawer}
-				deleteMessages={onClickDeleteButton}
-				treeName={messageDetail?.treeResponseDto.name}
-			/>
-			{messageDetail && (
-				<S.MessageDetailContainer>
-					<S.MessageContentContainer>
-						<MessageDetailHeader
-							profileImg={messageDetail.responseDto.senderProfileImage}
-							senderName={
-								messageDetail.responseDto.anonymous === false ? messageDetail.responseDto.senderNickname : '익명'
-							}
-							isLike={messageDetail.responseDto.favorite}
-							messageId={messageDetail.responseDto.id}
-							onToggleLike={onToggleLike}
-							treeId={treeId}
-						/>
-
-						<S.MessageContent>{messageDetail.responseDto.content}</S.MessageContent>
-					</S.MessageContentContainer>
-					<S.MessageNavButtonContainer>
-						<S.Button onClick={() => onClickNavButton(messageDetail.prevId)} disabled={messageDetail.prevId === 0}>
-							<S.ArrowDownIcon src={ArrowDownIcon} alt="" />
-							이전 메시지
-						</S.Button>
-
-						<S.Button onClick={() => onClickNavButton(messageDetail.nextId)} disabled={messageDetail.nextId === 0}>
-							다음 메시지
-							<S.ArrowIcon src={ArrowUpIcon} alt="" />
-						</S.Button>
-					</S.MessageNavButtonContainer>
-				</S.MessageDetailContainer>
-			)}
-			<SideDrawer onModal={openedDrawer} setOnModal={onToggleOpenDrawer} />
-			{isOpenDeleteModal && (
-				<AlertModal
-					isOpen={isOpenDeleteModal}
-					modalTitle="메세지"
-					modalMainImage="deleteMessageModal"
-					modalDescMessages={[
-						'메시지 삭제 시',
-						'메세지함에 있던 메시지가 삭제되며',
-						'삭제 후에는 복구할 수 없어요',
-						'정말 삭제하시겠습니까?',
-					]}
-					buttonTitle="삭제하기"
-					handleCloseBtnClick={() => {
-						setIsOpenDeleteModal(false);
-					}}
-					handleMainBtnClick={deleteMessageHandler}
-				/>
-			)}
-			{messageId && isMoving && (
-				<MovingFolderModal
-					isMoving={isMoving}
+		<Layout path="private">
+			<S.Wrapper>
+				<MessageMenu
+					isEdit={true}
 					onToggleMovingFolderModal={onToggleMovingFolderModal}
-					checkMessages={[Number(messageId)]}
-					handleAfterAction={onMoveToNextMessage}
+					onToggleOpenDrawer={onToggleOpenDrawer}
+					deleteMessages={onClickDeleteButton}
+					treeName={messageDetail?.treeResponseDto.name}
 				/>
-			)}
-			{errorToastText && <ErrorToast />}
-		</S.Wrapper>
+				{messageDetail && (
+					<S.MessageDetailContainer>
+						<S.MessageContentContainer>
+							<MessageDetailHeader
+								profileImg={messageDetail.responseDto.senderProfileImage}
+								senderName={
+									messageDetail.responseDto.anonymous === false ? messageDetail.responseDto.senderNickname : '익명'
+								}
+								isLike={messageDetail.responseDto.favorite}
+								messageId={messageDetail.responseDto.id}
+								onToggleLike={onToggleLike}
+								treeId={treeId}
+							/>
+
+							<S.MessageContent>{messageDetail.responseDto.content}</S.MessageContent>
+						</S.MessageContentContainer>
+						<S.MessageNavButtonContainer>
+							<S.Button onClick={() => onClickNavButton(messageDetail.prevId)} disabled={messageDetail.prevId === 0}>
+								<S.ArrowDownIcon src={ArrowDownIcon} alt="" />
+								이전 메시지
+							</S.Button>
+
+							<S.Button onClick={() => onClickNavButton(messageDetail.nextId)} disabled={messageDetail.nextId === 0}>
+								다음 메시지
+								<S.ArrowIcon src={ArrowUpIcon} alt="" />
+							</S.Button>
+						</S.MessageNavButtonContainer>
+					</S.MessageDetailContainer>
+				)}
+				<SideDrawer onModal={openedDrawer} setOnModal={onToggleOpenDrawer} />
+				{isOpenDeleteModal && (
+					<AlertModal
+						isOpen={isOpenDeleteModal}
+						modalTitle="메세지"
+						modalMainImage="deleteMessageModal"
+						modalDescMessages={[
+							'메시지 삭제 시',
+							'메세지함에 있던 메시지가 삭제되며',
+							'삭제 후에는 복구할 수 없어요',
+							'정말 삭제하시겠습니까?',
+						]}
+						buttonTitle="삭제하기"
+						handleCloseBtnClick={() => {
+							setIsOpenDeleteModal(false);
+						}}
+						handleMainBtnClick={deleteMessageHandler}
+					/>
+				)}
+				{messageId && isMoving && (
+					<MovingFolderModal
+						isMoving={isMoving}
+						onToggleMovingFolderModal={onToggleMovingFolderModal}
+						checkMessages={[Number(messageId)]}
+						handleAfterAction={onMoveToNextMessage}
+					/>
+				)}
+				{errorToastText && <ErrorToast />}
+			</S.Wrapper>
+		</Layout>
 	);
 };
 

--- a/src/pages/MessageSender/index.tsx
+++ b/src/pages/MessageSender/index.tsx
@@ -1,19 +1,20 @@
-import React, { useRef, useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import * as S from './MessageSender.styled';
-import { RecipientName, FolderSelect, MessageInput, AnonymousCheckBox } from '@/components/features/MessageSender';
-import Button from '@/components/shared/Button';
-import { MediumAlertModal, SuccessModal } from '@/components/shared';
-import { useQuery, useMutation } from 'react-query';
-import { useRecoilValue } from 'recoil';
-import { myInfoState } from '@/stores/user';
 import { getForest } from '@/apis/forest';
-import { DEFAULT_FOLDER_NAME } from '@/constants/messageSender';
-import { Folder } from '@/types/forest';
 import { postMessages } from '@/apis/messages';
-import PencilImg from '@/assets/images/shared/pencil.png';
-import WaterImg from '@/assets/images/noticeTree/watering_icon.png';
 import SadBeeImg from '@/assets/images/mypage/logout_bee_img@2x.png';
+import WaterImg from '@/assets/images/noticeTree/watering_icon.png';
+import PencilImg from '@/assets/images/shared/pencil.png';
+import { AnonymousCheckBox, FolderSelect, MessageInput, RecipientName } from '@/components/features/MessageSender';
+import { Layout } from '@/components/layout';
+import { MediumAlertModal, SuccessModal } from '@/components/shared';
+import Button from '@/components/shared/Button';
+import { DEFAULT_FOLDER_NAME } from '@/constants/messageSender';
+import { myInfoState } from '@/stores/user';
+import { Folder } from '@/types/forest';
+import React, { useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery } from 'react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import * as S from './MessageSender.styled';
 
 const MessageSender = () => {
 	const navigate = useNavigate();
@@ -29,8 +30,7 @@ const MessageSender = () => {
 		onSuccess: () => {
 			setIsSucceedSendMessage(true);
 		},
-		onError: (error) => {
-			console.log(error);
+		onError: () => {
 			setIsFailedSendMessage(true);
 		},
 	});
@@ -92,69 +92,71 @@ const MessageSender = () => {
 	}, [trees, treeId]);
 
 	return (
-		<S.Container>
-			<S.Background />
-			<S.MessageSenderContainer onSubmit={handleSubmitMessage}>
-				<S.TopWrapper>
-					<RecipientName name={recipientName} />
-					<FolderSelect
-						folders={trees}
-						isOpenedFolderBox={isOpenedSelectFolderBox}
-						onToggleSelectedFolderBox={onToggleSelectedFolderBox}
-						selectedFolder={selectedFolder}
-						handleSelectedFolderChange={handleSelectedFolderChange}
-					/>
-				</S.TopWrapper>
+		<Layout path={myInfo ? 'private' : 'public'}>
+			<S.Container>
+				<S.Background />
+				<S.MessageSenderContainer onSubmit={handleSubmitMessage}>
+					<S.TopWrapper>
+						<RecipientName name={recipientName} />
+						<FolderSelect
+							folders={trees}
+							isOpenedFolderBox={isOpenedSelectFolderBox}
+							onToggleSelectedFolderBox={onToggleSelectedFolderBox}
+							selectedFolder={selectedFolder}
+							handleSelectedFolderChange={handleSelectedFolderChange}
+						/>
+					</S.TopWrapper>
 
-				<S.MessageInputWrapper>
-					<MessageInput messageInputRef={messageInputRef} />
-				</S.MessageInputWrapper>
+					<S.MessageInputWrapper>
+						<MessageInput messageInputRef={messageInputRef} />
+					</S.MessageInputWrapper>
 
-				<S.AnonymousCheckBoxWrapper>
-					<AnonymousCheckBox checked={checkAnonymous} handleToggleChecked={onToggleCheckAnonymous} />
-				</S.AnonymousCheckBoxWrapper>
+					<S.AnonymousCheckBoxWrapper>
+						<AnonymousCheckBox checked={checkAnonymous} handleToggleChecked={onToggleCheckAnonymous} />
+					</S.AnonymousCheckBoxWrapper>
 
-				<S.ButtonWrapper>
-					<Button type="button" bgColor="normal" fontWeight="medium" onClick={onGoBackClick}>
-						뒤로가기
-					</Button>
-					<Button type="submit" bgColor="primary" fontWeight="bold">
-						물 주기
-					</Button>
-				</S.ButtonWrapper>
+					<S.ButtonWrapper>
+						<Button type="button" bgColor="normal" fontWeight="medium" onClick={onGoBackClick}>
+							뒤로가기
+						</Button>
+						<Button type="submit" bgColor="primary" fontWeight="bold">
+							물 주기
+						</Button>
+					</S.ButtonWrapper>
 
-				{isSucceedSendMessage && (
-					<SuccessModal
-						image={WaterImg}
-						title={'물 주기 완료!'}
-						messages={['따듯한 메시지를 무사히 전달했어요.', '덕분에 나무가 한 뼘 자라날 수 있게 되었어요!']}
-						buttonText={'닫기'}
-						isSucceedSendMessage={isSucceedSendMessage}
-						handleCloseBtnClick={onGoBackClick}
-					/>
-				)}
-				{isFailedSendMessage && (
-					<SuccessModal
-						image={SadBeeImg}
-						title={'물 주기 실패!'}
-						messages={['메시지를 전달하지 못했어요.', '다시 시도해주세요!']}
-						buttonText={'닫기'}
-						isSucceedSendMessage={isFailedSendMessage}
-						handleCloseBtnClick={() => setIsFailedSendMessage(false)}
-					/>
-				)}
-				{isMessageTextSizeAlertVisible && (
-					<MediumAlertModal
-						image={PencilImg}
-						width={200}
-						height={200}
-						contents={['10자 이상, 1000자 이하로', '메시지를 작성해야 해요!']}
-						buttonText={'닫기'}
-						modalHandler={() => setIsMessageTextSizeAlertVisible(false)}
-					/>
-				)}
-			</S.MessageSenderContainer>
-		</S.Container>
+					{isSucceedSendMessage && (
+						<SuccessModal
+							image={WaterImg}
+							title={'물 주기 완료!'}
+							messages={['따듯한 메시지를 무사히 전달했어요.', '덕분에 나무가 한 뼘 자라날 수 있게 되었어요!']}
+							buttonText={'닫기'}
+							isSucceedSendMessage={isSucceedSendMessage}
+							handleCloseBtnClick={onGoBackClick}
+						/>
+					)}
+					{isFailedSendMessage && (
+						<SuccessModal
+							image={SadBeeImg}
+							title={'물 주기 실패!'}
+							messages={['메시지를 전달하지 못했어요.', '다시 시도해주세요!']}
+							buttonText={'닫기'}
+							isSucceedSendMessage={isFailedSendMessage}
+							handleCloseBtnClick={() => setIsFailedSendMessage(false)}
+						/>
+					)}
+					{isMessageTextSizeAlertVisible && (
+						<MediumAlertModal
+							image={PencilImg}
+							width={200}
+							height={200}
+							contents={['10자 이상, 1000자 이하로', '메시지를 작성해야 해요!']}
+							buttonText={'닫기'}
+							modalHandler={() => setIsMessageTextSizeAlertVisible(false)}
+						/>
+					)}
+				</S.MessageSenderContainer>
+			</S.Container>
+		</Layout>
 	);
 };
 

--- a/src/pages/MessageSender/index.tsx
+++ b/src/pages/MessageSender/index.tsx
@@ -19,10 +19,12 @@ import * as S from './MessageSender.styled';
 const MessageSender = () => {
 	const navigate = useNavigate();
 	const { treeId } = useParams();
+	const { treeUserId } = useParams();
+	const { treeOwner } = useParams();
 
 	const myInfo = useRecoilValue(myInfoState);
 
-	const { data: trees } = useQuery(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
+	const { data: treeInfo } = useQuery(['getForest', myInfo?.id], () => getForest(myInfo?.id), {
 		enabled: !!myInfo,
 	});
 
@@ -36,13 +38,15 @@ const MessageSender = () => {
 	});
 
 	const messageInputRef = useRef<HTMLTextAreaElement>(null);
-	const [recipientName, setRecipientName] = useState('나에게');
+
 	const [checkAnonymous, setCheckAnonymous] = useState(false);
 	const [selectedFolder, setSelectedFolder] = useState(DEFAULT_FOLDER_NAME);
 	const [isOpenedSelectFolderBox, setIsOpenedSelectedFolderBox] = useState(false);
 	const [isSucceedSendMessage, setIsSucceedSendMessage] = useState(false);
 	const [isFailedSendMessage, setIsFailedSendMessage] = useState(false);
 	const [isMessageTextSizeAlertVisible, setIsMessageTextSizeAlertVisible] = useState(false);
+
+	const recipientName = treeOwner ? `${treeOwner}에게` : '나에게';
 
 	const handleSelectedFolderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const selected = event.target.value;
@@ -75,8 +79,8 @@ const MessageSender = () => {
 		return {
 			anonymous: checkAnonymous,
 			content: messageInputRef.current?.value as string,
-			folderId: trees?.filter((tree) => tree.name === selectedFolder)[0]?.id ?? null,
-			receiverId: myInfo?.id as number,
+			folderId: treeInfo?.responseDtoList?.filter((tree) => tree.name === selectedFolder)[0]?.id ?? null,
+			receiverId: treeUserId ? Number(treeUserId) : (myInfo?.id as number),
 		};
 	};
 
@@ -88,8 +92,8 @@ const MessageSender = () => {
 		trees?.filter((tree) => String(tree.id) === targetTreeId)[0]?.name || DEFAULT_FOLDER_NAME;
 
 	useEffect(() => {
-		setSelectedFolder(setInitialSelectedFolder(trees, String(treeId)));
-	}, [trees, treeId]);
+		setSelectedFolder(setInitialSelectedFolder(treeInfo?.responseDtoList, String(treeId)));
+	}, [treeInfo, treeId]);
 
 	return (
 		<Layout path={myInfo ? 'private' : 'public'}>
@@ -99,7 +103,7 @@ const MessageSender = () => {
 					<S.TopWrapper>
 						<RecipientName name={recipientName} />
 						<FolderSelect
-							folders={trees}
+							folders={treeInfo?.responseDtoList}
 							isOpenedFolderBox={isOpenedSelectFolderBox}
 							onToggleSelectedFolderBox={onToggleSelectedFolderBox}
 							selectedFolder={selectedFolder}

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,18 +1,21 @@
-import React from 'react';
-import { MyInfo, MyContents } from '@/components/features/MyPage';
-import * as S from './MyPage.styled';
+import { MyContents, MyInfo } from '@/components/features/MyPage';
 import ServicePolicy from '@/components/features/MyPage/ServicePolicy';
+import { Layout } from '@/components/layout';
 import withAuth from '@/utils/HOC/withAuth';
+import React from 'react';
+import * as S from './MyPage.styled';
 
 const MyPage = () => {
 	return (
-		<S.MyPageContainer>
-			<div>
-				<MyInfo />
-				<MyContents />
-			</div>
-			<ServicePolicy />
-		</S.MyPageContainer>
+		<Layout path={'private'}>
+			<S.MyPageContainer>
+				<div>
+					<MyInfo />
+					<MyContents />
+				</div>
+				<ServicePolicy />
+			</S.MyPageContainer>
+		</Layout>
 	);
 };
 

--- a/src/pages/MyPage/ProfileEdit/index.tsx
+++ b/src/pages/MyPage/ProfileEdit/index.tsx
@@ -1,14 +1,15 @@
+import { editProfile } from '@/apis/users';
+import { Layout } from '@/components/layout';
+import { SmallAlertModal } from '@/components/shared';
+import { RESPONSE_SUCCESS_OK } from '@/constants/api';
+import useInput from '@/hooks/useInput';
+import { smallModalState } from '@/stores/modal';
+import { myInfoState } from '@/stores/user';
+import withAuth from '@/utils/HOC/withAuth';
 import React from 'react';
-import * as S from './ProfileEdit.styled';
 import { Link, useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
-import { myInfoState } from '@/stores/user';
-import useInput from '@/hooks/useInput';
-import { editProfile } from '@/apis/users';
-import { RESPONSE_SUCCESS_OK } from '@/constants/api';
-import withAuth from '@/utils/HOC/withAuth';
-import { SmallAlertModal } from '@/components/shared';
-import { smallModalState } from '@/stores/modal';
+import * as S from './ProfileEdit.styled';
 
 const ProfileEdit = () => {
 	const [myInfo, setMyInfo] = useRecoilState(myInfoState);
@@ -45,7 +46,7 @@ const ProfileEdit = () => {
 	};
 
 	return (
-		<>
+		<Layout path="private">
 			<main>
 				<S.ProfileEditForm onSubmit={handleSubmitEditProfileForm}>
 					<S.ProfileEditWrapper>
@@ -61,7 +62,7 @@ const ProfileEdit = () => {
 				</S.ProfileEditForm>
 			</main>
 			{smallModal && <SmallAlertModal />}
-		</>
+		</Layout>
 	);
 };
 

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,21 +1,24 @@
-import React from 'react';
 import NotFoundIcon from '@/assets/images/shared/not_found.svg';
-import * as S from './NotFound.styled';
+import { Layout } from '@/components/layout';
 import Button from '@/components/shared/Button';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import * as S from './NotFound.styled';
 
 const NotFound = () => {
 	const navigate = useNavigate();
 	return (
-		<S.Wrapper>
-			<S.Content>
-				<img src={NotFoundIcon} alt="" />
-				<span>Page Not Found</span>
-			</S.Content>
-			<Button type="button" bgColor="primary" onClick={() => navigate('/')}>
-				돌아가기
-			</Button>
-		</S.Wrapper>
+		<Layout path="public">
+			<S.Wrapper>
+				<S.Content>
+					<img src={NotFoundIcon} alt="" />
+					<span>Page Not Found</span>
+				</S.Content>
+				<Button type="button" bgColor="primary" onClick={() => navigate('/')}>
+					돌아가기
+				</Button>
+			</S.Wrapper>
+		</Layout>
 	);
 };
 

--- a/src/pages/NoticeTree/index.tsx
+++ b/src/pages/NoticeTree/index.tsx
@@ -2,6 +2,7 @@ import { updateReadMessage } from '@/apis/messages';
 import { getNotices } from '@/apis/noticeTree';
 import NoMessageIcon from '@/assets/images/noticeTree/no_message.png';
 import { AlertPopUp, Clouds, MessageBox, Tree, WateringButton } from '@/components/features/NoticeTree';
+import { Layout } from '@/components/layout';
 import { ErrorToast, MediumAlertModal } from '@/components/shared';
 import { errorToastState } from '@/stores/modal';
 import { myInfoState } from '@/stores/user';
@@ -101,7 +102,8 @@ const NoticeTree = () => {
 	}, [noticeMessages]);
 
 	return (
-		<>
+		<Layout path="private">
+			{' '}
 			<S.TemporaryWrapper>
 				<Clouds />
 				<S.NoticeTextWrapper>
@@ -130,7 +132,7 @@ const NoticeTree = () => {
 					buttonText="닫기"
 				/>
 			)}
-		</>
+		</Layout>
 	);
 };
 

--- a/src/pages/NoticeTree/index.tsx
+++ b/src/pages/NoticeTree/index.tsx
@@ -103,35 +103,36 @@ const NoticeTree = () => {
 
 	return (
 		<Layout path="private">
-			{' '}
-			<S.TemporaryWrapper>
-				<Clouds />
-				<S.NoticeTextWrapper>
-					<S.NoticeMainText>
-						{username}의 알림나무<span>읽지 않은 열매 {unreadCount} </span>
-					</S.NoticeMainText>
-				</S.NoticeTextWrapper>
-				<Tree updateReadMessageHandler={updateReadMessageHandler} messages={noticeMessages ? noticeMessages : null} />
-				<AlertPopUp
-					username={username}
-					messageCount={unreadCount}
-					showAlertMessage={showAlertMessage}
-					activeHomeAlert={activeHomeAlert}
-				/>
-				{showMessage && <MessageBox selectedMessage={selectedMessage} showMessageHandler={showMessageHandler} />}
-				<WateringButton />
-				{errorToastText && <ErrorToast />}
-			</S.TemporaryWrapper>
-			{onAlertModal && (
-				<MediumAlertModal
-					image={NoMessageIcon}
-					width={268}
-					height={268}
-					contents={['새롭게 도착한 메시지가 없습니다.']}
-					modalHandler={modalHandler}
-					buttonText="닫기"
-				/>
-			)}
+			<>
+				<S.TemporaryWrapper>
+					<Clouds />
+					<S.NoticeTextWrapper>
+						<S.NoticeMainText>
+							{username}의 알림나무<span>읽지 않은 열매 {unreadCount} </span>
+						</S.NoticeMainText>
+					</S.NoticeTextWrapper>
+					<Tree updateReadMessageHandler={updateReadMessageHandler} messages={noticeMessages ? noticeMessages : null} />
+					<AlertPopUp
+						username={username}
+						messageCount={unreadCount}
+						showAlertMessage={showAlertMessage}
+						activeHomeAlert={activeHomeAlert}
+					/>
+					{showMessage && <MessageBox selectedMessage={selectedMessage} showMessageHandler={showMessageHandler} />}
+					<WateringButton />
+					{errorToastText && <ErrorToast />}
+				</S.TemporaryWrapper>
+				{onAlertModal && (
+					<MediumAlertModal
+						image={NoMessageIcon}
+						width={268}
+						height={268}
+						contents={['새롭게 도착한 메시지가 없습니다.']}
+						modalHandler={modalHandler}
+						buttonText="닫기"
+					/>
+				)}
+			</>
 		</Layout>
 	);
 };

--- a/src/pages/PublicForest/Forest.styled.ts
+++ b/src/pages/PublicForest/Forest.styled.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const TreesContainer = styled.main`
+	padding: 96px 0 30px 0;
+	margin: 0 32px;
+`;
+
+export const TreeListBox = styled.div`
+	margin-top: 34px;
+`;
+
+export const ButtonBox = styled.div`
+	display: flex;
+	justify-content: center;
+	margin-top: 42px;
+`;

--- a/src/pages/PublicForest/index.tsx
+++ b/src/pages/PublicForest/index.tsx
@@ -3,8 +3,8 @@ import TreeList from '@/components/features/Forest/TreeList';
 import { Header, Layout } from '@/components/layout';
 import Button from '@/components/shared/Button';
 import MessageChip from '@/components/shared/Chip/MessageChip';
-import { Folder } from '@/types/forest';
-import React, { useEffect } from 'react';
+import { Folder, ForestTrees } from '@/types/forest';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
@@ -18,9 +18,19 @@ const PublicForest = () => {
 
 	const { userId } = useParams();
 
-	const { data: folders } = useQuery<Folder[] | undefined>(['getForest', userId], () => getForest(userId), {
+	const [treeFolders, setTreeFolders] = useState<Folder[] | undefined>(undefined);
+	const [treeOwner, setTreeOwner] = useState('');
+
+	const { data: folders } = useQuery<ForestTrees | undefined>(['getForest', userId], () => getForest(userId), {
 		enabled: !!userId,
 	});
+
+	useEffect(() => {
+		if (folders) {
+			setTreeFolders(folders.responseDtoList);
+			setTreeOwner(folders.nickname);
+		}
+	}, [folders]);
 
 	useEffect(() => {
 		if (!userId) {
@@ -33,12 +43,12 @@ const PublicForest = () => {
 			<>
 				{!myInfo && <Header />}
 				<S.TreesContainer>
-					<MessageChip message="오늘 하루도 고생한 우리에게 따듯한 칭찬을 남겨보세요!" />
+					<MessageChip message={`오늘 하루도 고생한 ${treeOwner}님에게 따듯한 칭찬을 남겨보세요!`} />
 
-					<S.TreeListBox>{folders && <TreeList trees={folders} />}</S.TreeListBox>
+					<S.TreeListBox>{folders && <TreeList trees={treeFolders} />}</S.TreeListBox>
 
 					<S.ButtonBox>
-						<Button type="button" bgColor="primary" onClick={() => navigate('/message/edit')}>
+						<Button type="button" bgColor="primary" onClick={() => navigate(`/message/edit/${userId}/${treeOwner}`)}>
 							나무에 물 주기
 						</Button>
 					</S.ButtonBox>

--- a/src/pages/PublicForest/index.tsx
+++ b/src/pages/PublicForest/index.tsx
@@ -1,0 +1,51 @@
+import { getForest } from '@/apis/forest';
+import TreeList from '@/components/features/Forest/TreeList';
+import { Header, Layout } from '@/components/layout';
+import Button from '@/components/shared/Button';
+import MessageChip from '@/components/shared/Chip/MessageChip';
+import { Folder } from '@/types/forest';
+import React, { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { myInfoState } from '../../stores/user';
+import * as S from './Forest.styled';
+
+const PublicForest = () => {
+	const navigate = useNavigate();
+
+	const myInfo = useRecoilValue(myInfoState);
+
+	const { userId } = useParams();
+
+	const { data: folders } = useQuery<Folder[] | undefined>(['getForest', userId], () => getForest(userId), {
+		enabled: !!userId,
+	});
+
+	useEffect(() => {
+		if (!userId) {
+			navigate('/forest');
+		}
+	}, []);
+
+	return (
+		<Layout path={myInfo ? 'private' : 'public'}>
+			<>
+				{!myInfo && <Header />}
+				<S.TreesContainer>
+					<MessageChip message="오늘 하루도 고생한 우리에게 따듯한 칭찬을 남겨보세요!" />
+
+					<S.TreeListBox>{folders && <TreeList trees={folders} />}</S.TreeListBox>
+
+					<S.ButtonBox>
+						<Button type="button" bgColor="primary" onClick={() => navigate('/message/edit')}>
+							나무에 물 주기
+						</Button>
+					</S.ButtonBox>
+				</S.TreesContainer>
+			</>
+		</Layout>
+	);
+};
+
+export default PublicForest;

--- a/src/pages/TreeDetail/index.tsx
+++ b/src/pages/TreeDetail/index.tsx
@@ -3,6 +3,7 @@ import { updateReadMessage } from '@/apis/messages';
 import LeftButton from '@/assets/images/trees/tree_left_button.svg';
 import RightButton from '@/assets/images/trees/tree_right_button.svg';
 import { Clouds, MessageBox, Tree, WateringButton } from '@/components/features/NoticeTree';
+import { Header, Layout } from '@/components/layout';
 import { ErrorToast } from '@/components/shared';
 import { errorToastState } from '@/stores/modal';
 import { myInfoState } from '@/stores/user';
@@ -68,42 +69,48 @@ const TreeDetail = () => {
 	}, [treeDetailInfo]);
 
 	return (
-		<>
-			<S.TemporaryWrapper>
-				<Clouds />
+		<Layout path={myInfo ? 'private' : 'public'}>
+			<>
+				{!myInfo && <Header />}
+				<S.TemporaryWrapper>
+					<Clouds />
 
-				<S.TreeDetailTextWrapper>
-					<S.TreeDetailMainText>
-						{treeDetailInfo?.name === 'DEFAULT' ? '기본폴더' : treeDetailInfo?.name}
-					</S.TreeDetailMainText>
-					<span>맺혀 있는 열매 : {treeMessages?.length}개</span>
-				</S.TreeDetailTextWrapper>
+					<S.TreeDetailTextWrapper>
+						<S.TreeDetailMainText>
+							{treeDetailInfo?.name === 'DEFAULT' ? '기본폴더' : treeDetailInfo?.name}
+						</S.TreeDetailMainText>
+						<span>맺혀 있는 열매 : {treeMessages?.length}개</span>
+					</S.TreeDetailTextWrapper>
 
-				<Tree
-					fruitType={treeDetailInfo?.fruitType}
-					updateReadMessageHandler={updateReadMessageHandler}
-					messages={treeMessages}
-				/>
+					<Tree
+						fruitType={treeDetailInfo?.fruitType}
+						updateReadMessageHandler={updateReadMessageHandler}
+						messages={treeMessages}
+					/>
 
-				{showMessage && (
-					<MessageBox selectedMessage={selectedMessage} showMessageHandler={() => setShowMessage(false)} />
-				)}
+					{showMessage && (
+						<MessageBox selectedMessage={selectedMessage} showMessageHandler={() => setShowMessage(false)} />
+					)}
+					{myInfo && (
+						<>
+							<WateringButton treeId={treeId} />
 
-				<WateringButton treeId={treeId} />
-
-				{treeDetailInfo?.prevId !== 0 && (
-					<S.PrevButton onClick={() => moveTree(treeDetailInfo?.prevId)}>
-						<img src={LeftButton} alt="이전 메세지 이동" />
-					</S.PrevButton>
-				)}
-				{treeDetailInfo?.nextId !== 0 && (
-					<S.NextButton onClick={() => moveTree(treeDetailInfo?.nextId)}>
-						<img src={RightButton} alt="다음 메세지 이동" />
-					</S.NextButton>
-				)}
-				{errorToastText && <ErrorToast />}
-			</S.TemporaryWrapper>
-		</>
+							{treeDetailInfo?.prevId !== 0 && (
+								<S.PrevButton onClick={() => moveTree(treeDetailInfo?.prevId)}>
+									<img src={LeftButton} alt="이전 메세지 이동" />
+								</S.PrevButton>
+							)}
+							{treeDetailInfo?.nextId !== 0 && (
+								<S.NextButton onClick={() => moveTree(treeDetailInfo?.nextId)}>
+									<img src={RightButton} alt="다음 메세지 이동" />
+								</S.NextButton>
+							)}
+						</>
+					)}
+					{errorToastText && <ErrorToast />}
+				</S.TemporaryWrapper>
+			</>
+		</Layout>
 	);
 };
 

--- a/src/pages/TreeDetail/index.tsx
+++ b/src/pages/TreeDetail/index.tsx
@@ -3,7 +3,7 @@ import { updateReadMessage } from '@/apis/messages';
 import LeftButton from '@/assets/images/trees/tree_left_button.svg';
 import RightButton from '@/assets/images/trees/tree_right_button.svg';
 import { Clouds, MessageBox, Tree, WateringButton } from '@/components/features/NoticeTree';
-import { Header, Layout } from '@/components/layout';
+import { Header, Layout, PublicBottomNav } from '@/components/layout';
 import { ErrorToast } from '@/components/shared';
 import { errorToastState } from '@/stores/modal';
 import { myInfoState } from '@/stores/user';
@@ -16,6 +16,7 @@ import * as S from './TreeDetail.styled';
 
 const TreeDetail = () => {
 	const { treeId } = useParams();
+	const { treeUserId } = useParams();
 
 	const navigate = useNavigate();
 
@@ -26,7 +27,7 @@ const TreeDetail = () => {
 	const [selectedMessage, setSelectedMessage] = useState<MessageWithLocationType | null>(null);
 	const [treeMessages, setTreeMessages] = useState<MessageWithLocationType[] | null>(null);
 
-	const userId = myInfo?.id;
+	const userId = myInfo ? myInfo.id : treeUserId;
 
 	const { data: treeDetailInfo } = useQuery(
 		['readTreeDetail', { treeId: treeId, userId: userId }],
@@ -42,7 +43,7 @@ const TreeDetail = () => {
 	const updateReadMessageHandler = (messageId: number, selectedIdx: number) => {
 		try {
 			if (treeMessages) {
-				updateReadMessage(messageId);
+				!treeUserId && updateReadMessage(messageId);
 				setShowMessage(true);
 				setSelectedMessage(treeMessages[selectedIdx]);
 			}
@@ -109,6 +110,7 @@ const TreeDetail = () => {
 					)}
 					{errorToastText && <ErrorToast />}
 				</S.TemporaryWrapper>
+				{!myInfo && <PublicBottomNav />}
 			</>
 		</Layout>
 	);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
-export { default as MessageBox } from './MessageBox';
-export { default as NoticeTree } from './NoticeTree';
 export { default as Forest } from './Forest';
-export { default as MessageSender } from './MessageSender';
-export { default as MessageDetail } from './MessageDetail';
-export { default as MyPage } from './MyPage/MyPage';
-export { default as TreeDetail } from './TreeDetail';
-export { default as NotFound } from './NotFound';
 export { default as Landing } from './Landing';
+export { default as MessageBox } from './MessageBox';
+export { default as MessageDetail } from './MessageDetail';
+export { default as MessageSender } from './MessageSender';
+export { default as MyPage } from './MyPage/MyPage';
+export { default as NotFound } from './NotFound';
+export { default as NoticeTree } from './NoticeTree';
+export { default as PublicForest } from './PublicForest';
+export { default as TreeDetail } from './TreeDetail';

--- a/src/types/forest.ts
+++ b/src/types/forest.ts
@@ -4,6 +4,11 @@ export type Folder = {
 	fruit: React.SetStateAction<string | undefined>;
 };
 
+export interface ForestTrees {
+	responseDtoList: Folder[];
+	nickname: string;
+}
+
 export type Param = string | undefined;
 
 export interface TreeDetailParam {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- #97  
- 레이아웃 퍼블릭/프라이빗 구분


<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 기존 라우터를 레이아웃으로 래핑하는 방법에서 각 페이지별로 레이아웃을 유저인포를 통해 퍼블릭과 프라이빗으로 구분하여 개별 레이아웃하는 방식으로 변경하였습니다. 
- 현재로써 리액트 라우터 돔으로 구분하는방식에 대한 이해가 부족하여 대안적으로 선택한 방법입니다. 
- 더 좋은 방법이 충분히 있을 것이므로 추후 리팩토링의 대상이라고 생각합니다. 



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.

